### PR TITLE
Fix #27: Remove HTML parsing from Python script and outsource CSS class assignment

### DIFF
--- a/src/layouts/podcast-episode.astro
+++ b/src/layouts/podcast-episode.astro
@@ -3,6 +3,8 @@ import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 
+import '../styles/podcast_episode.scss';
+
 const { content } = Astro.props;
 let canonicalURL = Astro.canonicalURL;
 
@@ -202,7 +204,9 @@ headline_split.forEach(function callback(val) {
               					<h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="headline-content">
 									Worum geht's?
 								</h3>
-								<slot />
+								<div id="slot">
+									<slot />
+								</div>
             				</div>
           				</div>
         			</div>

--- a/src/pages/podcast/episode/00-developer-fangen-bei-0-an-zu-zählen.md
+++ b/src/pages/podcast/episode/00-developer-fangen-bei-0-an-zu-zählen.md
@@ -59,157 +59,169 @@ title: "#00 Developer fangen bei 0 an zu z\xE4hlen"
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Software Engineers fangen bei 0 an zu zählen. Das Engineering Kiosk ist direkt bei Episode 1 gestartet. Diesen Off-by-one error beheben wir nun mit dieser Folge 0.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Wir, Wolfgang und Andy, stellen uns als Hosts vor, erzählen wie es zu diesem Podcast kam, wie wir gestartet haben, was wir in den ersten fünf Folgen gelernt haben und wie die Podcast-Distribution technisch funktioniert.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Nebenbei erfahren wir den Unterschied zwischen dem deutschen und österreichischem Verständnis von Cafe, warum Bachelor ein anderes Wort für Studenabbrecher ist und was Ziegen damit zu tun haben.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Ob Kaiserschmarrn mit oder ohne Rosinen gemacht wird.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Deutsche Spotify Podcast Charts:
-    <a class="underline hover:no-underline" href="https://podcastcharts.byspotify.com/de" rel="nofollow">
+    <a href="https://podcastcharts.byspotify.com/de" rel="nofollow">
      https://podcastcharts.byspotify.com/de
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     TYPO3 Content Management System:
-    <a class="underline hover:no-underline" href="https://typo3.org/" rel="nofollow">
+    <a href="https://typo3.org/" rel="nofollow">
      https://typo3.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Codeprints:
-    <a class="underline hover:no-underline" href="https://codeprints.dev/" rel="nofollow">
+    <a href="https://codeprints.dev/" rel="nofollow">
      https://codeprints.dev/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Working Draft Podcast:
-    <a class="underline hover:no-underline" href="https://workingdraft.de/" rel="nofollow">
+    <a href="https://workingdraft.de/" rel="nofollow">
      https://workingdraft.de/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Audacity, open-source audio Schnitt Software:
-    <a class="underline hover:no-underline" href="https://www.audacityteam.org/" rel="nofollow">
+    <a href="https://www.audacityteam.org/" rel="nofollow">
      https://www.audacityteam.org/
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://scontent-ber1-1.cdninstagram.com/v/t51.2885-15/e35/33559529_1922740234443194_4987014148043833344_n.jpg?_nc_cat=102&amp;_nc_ht=scontent-ber1-1.cdninstagram.com&amp;_nc_ohc=u81to9-Eir4AX_eG9dv&amp;_nc_sid=30a2e&amp;ccb=7-4&amp;edm=ALQROFkBAAAA&amp;ig_cache_key=MTc5MjA1ODc4MzQyMjYyMDQ0NQ%3D%3D.2-ccb7-4&amp;oe=6208074E&amp;oh=00_AT_C5NJ9mkCP_-yvs5jcCQozb1cUgfIuJpS-clSBPqWFHw" rel="nofollow">
+   <li>
+    <a href="https://scontent-ber1-1.cdninstagram.com/v/t51.2885-15/e35/33559529_1922740234443194_4987014148043833344_n.jpg?_nc_cat=102&amp;_nc_ht=scontent-ber1-1.cdninstagram.com&amp;_nc_ohc=u81to9-Eir4AX_eG9dv&amp;_nc_sid=30a2e&amp;ccb=7-4&amp;edm=ALQROFkBAAAA&amp;ig_cache_key=MTc5MjA1ODc4MzQyMjYyMDQ0NQ%3D%3D.2-ccb7-4&amp;oe=6208074E&amp;oh=00_AT_C5NJ9mkCP_-yvs5jcCQozb1cUgfIuJpS-clSBPqWFHw" rel="nofollow">
      Ziegen-Bild
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:30) Gratulation zu 5 Episoden
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:43) Wer ist Wolfgang Gassler?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:59) ... Was willst du mal werden, wenn du groß bist?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:44) ... Was ist das letzte, nicht IT technische, was du gelernt hast?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:49) ... Was motiviert dich, dich jeden Tag erneut mit IT und Software Engineering zu beschäftigen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:05) ... Fakten-Check
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:29) ... Wolfgangs Personalakte
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:04) ... Wie viele Domains besitzt du, wo kein Side Projekt gestartet wurde?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:58) Wer ist Andy Grunwald?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:08) ... Was ist das erste, was du tust, wenn du einen Incident hast und wie Website down ist?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (09:12) ... Warum macht es dir soviel Spaß aufzuräumen und warum sind Ziegen auf deinem Instagram-Account?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (11:26) ... Welcher Spruch soll auf deinem Grabstein stehen oder auf einem Banner in deiner Heimatstadt Duisburg?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:03) ... Andys Personalakte
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (13:12) Warum machen wir das Engineering Kiosk?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (15:42) Wie haben wir den Podcast gestartet?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:01) Warum kommt die Folge 00 jetzt erst?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:15) Was haben wir von 5 Podcast Episoden bereits gelernt?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:28) Open Podcast
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (27:00) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/01-side-projects-fluch-oder-segen-für-die-karriere.md
+++ b/src/pages/podcast/episode/01-side-projects-fluch-oder-segen-für-die-karriere.md
@@ -54,141 +54,153 @@ title: "#01 Side Projects - Fluch oder Segen f\xFCr die Karriere?"
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Zwei Engineering Manager über Side Projects: Wie diese den Recruiting Prozess beeinflussen, welche Learnings aus einem Projekt generiert werden, was die freiwillige Feuerwehr mit Site Reliability Engineering zu tun hat, welche negativen Seiten Side Projects haben können, ob ein Hund auch ein eigenes Side Project ist und warum man nicht seinen eigenen Mailserver betreiben sollte.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Der Unterschied zwischen Schnacken und Schnackseln
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Andy (
-   <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <a href="https://twitter.com/andygrunwald" rel="nofollow">
     https://twitter.com/andygrunwald
    </a>
    ) und Wolfgang (
-   <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+   <a href="https://twitter.com/schafele" rel="nofollow">
     https://twitter.com/schafele
    </a>
    ) sprechen im Detail über:
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:26) Warum "Engineering Kiosk"? Woher kommt der Name?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:52) Einstieg ins Thema "Side Projects"
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:00) Side Projects im Recruiting Prozess und Lebenslauf
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:45) Muss das Side Project etwas mit dem Job zu tun haben?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:40) Alleine oder im Team?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:10) Was bringt dir die Information "Side Project" für das Interview selbst?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (11:25) Hire for Skill or for attitude
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:43) Kann ein Side Project auch etwas negatives bedeuten (als Hiring Manager)?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (14:55) Wolfgang erzählt aus dem Krieg: Sein Mail-Server Side-Project
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (18:31) Psychologischer Druck bei Side Projects
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (19:23) Learnings aus Side Projects
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (23:44) Rollen-, Zeit- und Energiemanagement: Side-Projects mit Familie/in der Freizeit
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (31:53) Side Projects als Ausgleich
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (34:10) Learnings aus dem Side Project im Job als Engineering Manager
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (36:27) Lohnen sich Side Projects für die Job-Suche?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (40:02) Wie Ihr eure Side Projects nutzen könnt um das Interview zu eurem Vorteil zu drehen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (42:45) Brauchen wir POP3 noch?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (43:34) Top Tip: Startet ein Side Project und setzt euch die richtigen Erwartungen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (44:39) Sind Arbeitgeber glücklich über Side Projects von MitarbeiterInnen?
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-personen">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-personen">
    Erwähnte Personen
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Tom Bartel (
-    <a class="underline hover:no-underline" href="https://twitter.com/twbartel" rel="nofollow">
+    <a href="https://twitter.com/twbartel" rel="nofollow">
      https://twitter.com/twbartel
     </a>
     /
-    <a class="underline hover:no-underline" href="https://www.tombartel.me/" rel="nofollow">
+    <a href="https://www.tombartel.me/" rel="nofollow">
      https://www.tombartel.me/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Joost Ronkes Agerbeek (
-    <a class="underline hover:no-underline" href="https://www.linkedin.com/in/joost-ronkes-agerbeek-46a41339/" rel="nofollow">
+    <a href="https://www.linkedin.com/in/joost-ronkes-agerbeek-46a41339/" rel="nofollow">
      https://www.linkedin.com/in/joost-ronkes-agerbeek-46a41339/
     </a>
     )
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Anfragen an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
   </p>

--- a/src/pages/podcast/episode/02-technologienzoo-side-projects.md
+++ b/src/pages/podcast/episode/02-technologienzoo-side-projects.md
@@ -76,443 +76,473 @@ title: '#02 Technologienzoo Side Projects'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Wolfgang und Andy erzählen ein wenig was über ihre eigenen Side Projects sourcectl (
-   <a class="underline hover:no-underline" href="https://gettoknow.sourcectl.dev/" rel="nofollow">
+   <a href="https://gettoknow.sourcectl.dev/" rel="nofollow">
     https://gettoknow.sourcectl.dev/
    </a>
    ), F-Online (
-   <a class="underline hover:no-underline" href="https://www.f-online.at/" rel="nofollow">
+   <a href="https://www.f-online.at/" rel="nofollow">
     https://www.f-online.at/
    </a>
    ) und the athlete (
-   <a class="underline hover:no-underline" href="https://theathlete.app/" rel="nofollow">
+   <a href="https://theathlete.app/" rel="nofollow">
     https://theathlete.app/
    </a>
    ).
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Wir machen eine Rundfahrt durch den verwendeten Technologienzoo, diskutieren ob man Monitoring in Side Projects benötigt, wann es Over-Engineering und wann gerechtfertigt ist, ob der heutige Einsatz von Zend Framework 1 schon als kriminell gewertet werden kann und hören Wolfgang zu, wie er DevOps Anfängerfehler begeht indem ihm die Festplatte voll logs läuft.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Bonus: Wie Wolfgang den ultimativen Reichtum mit seinem eigenen CMS zur dotcom Blase verpasst hat
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Andy (
-   <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <a href="https://twitter.com/andygrunwald" rel="nofollow">
     https://twitter.com/andygrunwald
    </a>
    ) und Wolfgang (
-   <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+   <a href="https://twitter.com/schafele" rel="nofollow">
     https://twitter.com/schafele
    </a>
    ) sprechen im Detail über:
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:03) Vorstellung von Andy und Wolfgang
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:18) Vorstellung Andy Grunwald
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:36) Vorstellung Wolfgang Gassler
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:11) Side Project "inspect": Automatische Generierung einer RabbitMQ Architektur
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (04:23) Was ist RabbitMQ?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:33) Side Project "sourcectl": Metrik Platform für Inner Source und Open Sorurce Projekte
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:32) sourcectl: Warum nutzt du RabbitMQ und keine Datenbank für das Message Queuing?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:48) sourcectl: Monitoring
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:55) sourcectl: Verarbeitung von Messages
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (09:50) sourcectl: Infrastruktur- und Application-Setup
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:01) Was zur Hölle ist ein OMR (vs. ein ORM)?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:53) Was ist Traefik: The Cloud Native Application Proxy?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (17:45) Traefik Pro und Overengineering: Loadbalancing über mehrere Server und verteilte SSL Zertifikate
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:00) Side Project "F-Online": Für den Führerschein in Österreich lernen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:34) F-Online: Hosting und Monitoring
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:27) Tipps um Kosten bei Google Cloud unter Kontrolle zu halten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (26:01) F-Online: Infrastruktur- und Application-Setup
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (26:42) Wolfgangs Leiche im Keller: Zend Framework 1 auf (teils) aktueller PHP Version
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (29:00) F-Online: JavaScript Architektur
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (31:29) F-Online: APIs
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (32:40) F-Online: Datenbank
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (34:39) F-Online: Wie es aussehen würde, wenn es nochmal neu gebaut werden würde
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (37:22) Engineers over-engineeren von Haus aus
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (37:40) Side Project "the athlete"
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (39:02) Ziele, Motivation und die (eigenen) Erwartungen an Side Projects
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (40:28) Wolfgang erzählt vom Krieg: Sein eigenes Content Management System
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (42:37) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-side-projects">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-side-projects">
    Erwähnte Side Projects
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     sourcectl (
-    <a class="underline hover:no-underline" href="https://gettoknow.sourcectl.dev/" rel="nofollow">
+    <a href="https://gettoknow.sourcectl.dev/" rel="nofollow">
      https://gettoknow.sourcectl.dev/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     F-Online (
-    <a class="underline hover:no-underline" href="https://www.f-online.at/" rel="nofollow">
+    <a href="https://www.f-online.at/" rel="nofollow">
      https://www.f-online.at/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     the athlete (
-    <a class="underline hover:no-underline" href="https://theathlete.app/" rel="nofollow">
+    <a href="https://theathlete.app/" rel="nofollow">
      https://theathlete.app/
     </a>
     )
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-technologien">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-technologien">
    Erwähnte Technologien
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     AMQP (
-    <a class="underline hover:no-underline" href="https://www.amqp.org/" rel="nofollow">
+    <a href="https://www.amqp.org/" rel="nofollow">
      https://www.amqp.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Babel (
-    <a class="underline hover:no-underline" href="https://babeljs.io/" rel="nofollow">
+    <a href="https://babeljs.io/" rel="nofollow">
      https://babeljs.io/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Backbone (
-    <a class="underline hover:no-underline" href="https://backbonejs.org/" rel="nofollow">
+    <a href="https://backbonejs.org/" rel="nofollow">
      https://backbonejs.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     DigitalOcean (
-    <a class="underline hover:no-underline" href="https://www.digitalocean.com/" rel="nofollow">
+    <a href="https://www.digitalocean.com/" rel="nofollow">
      https://www.digitalocean.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Docker (
-    <a class="underline hover:no-underline" href="https://www.docker.com/" rel="nofollow">
+    <a href="https://www.docker.com/" rel="nofollow">
      https://www.docker.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Flutter (
-    <a class="underline hover:no-underline" href="https://flutter.dev/" rel="nofollow">
+    <a href="https://flutter.dev/" rel="nofollow">
      https://flutter.dev/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     GitHub (
-    <a class="underline hover:no-underline" href="https://github.com/" rel="nofollow">
+    <a href="https://github.com/" rel="nofollow">
      https://github.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Go (
-    <a class="underline hover:no-underline" href="https://go.dev/" rel="nofollow">
+    <a href="https://go.dev/" rel="nofollow">
      https://go.dev/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Google Cloud Free-Tier (
-    <a class="underline hover:no-underline" href="https://cloud.google.com/free" rel="nofollow">
+    <a href="https://cloud.google.com/free" rel="nofollow">
      https://cloud.google.com/free
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Grafana (
-    <a class="underline hover:no-underline" href="https://grafana.com/" rel="nofollow">
+    <a href="https://grafana.com/" rel="nofollow">
      https://grafana.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     GraphQL API (
-    <a class="underline hover:no-underline" href="https://graphql.org/" rel="nofollow">
+    <a href="https://graphql.org/" rel="nofollow">
      https://graphql.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Grunt (
-    <a class="underline hover:no-underline" href="https://gruntjs.com/" rel="nofollow">
+    <a href="https://gruntjs.com/" rel="nofollow">
      https://gruntjs.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Hetzner Cloud (
-    <a class="underline hover:no-underline" href="https://www.hetzner.com/de/cloud" rel="nofollow">
+    <a href="https://www.hetzner.com/de/cloud" rel="nofollow">
      https://www.hetzner.com/de/cloud
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     JQuery (
-    <a class="underline hover:no-underline" href="https://jquery.com/" rel="nofollow">
+    <a href="https://jquery.com/" rel="nofollow">
      https://jquery.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Kubernetes (
-    <a class="underline hover:no-underline" href="https://kubernetes.io/" rel="nofollow">
+    <a href="https://kubernetes.io/" rel="nofollow">
      https://kubernetes.io/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Lets Encrypt (
-    <a class="underline hover:no-underline" href="https://letsencrypt.org/" rel="nofollow">
+    <a href="https://letsencrypt.org/" rel="nofollow">
      https://letsencrypt.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Marionette (
-    <a class="underline hover:no-underline" href="https://marionettejs.com/" rel="nofollow">
+    <a href="https://marionettejs.com/" rel="nofollow">
      https://marionettejs.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     MooTools (
-    <a class="underline hover:no-underline" href="https://mootools.net/" rel="nofollow">
+    <a href="https://mootools.net/" rel="nofollow">
      https://mootools.net/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     MySQL (
-    <a class="underline hover:no-underline" href="https://www.mysql.com/" rel="nofollow">
+    <a href="https://www.mysql.com/" rel="nofollow">
      https://www.mysql.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Nginx (
-    <a class="underline hover:no-underline" href="https://www.nginx.com/" rel="nofollow">
+    <a href="https://www.nginx.com/" rel="nofollow">
      https://www.nginx.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     PHP (
-    <a class="underline hover:no-underline" href="https://www.php.net/" rel="nofollow">
+    <a href="https://www.php.net/" rel="nofollow">
      https://www.php.net/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Prometheus (
-    <a class="underline hover:no-underline" href="https://prometheus.io/" rel="nofollow">
+    <a href="https://prometheus.io/" rel="nofollow">
      https://prometheus.io/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     RabbitMQ (
-    <a class="underline hover:no-underline" href="https://www.rabbitmq.com/" rel="nofollow">
+    <a href="https://www.rabbitmq.com/" rel="nofollow">
      https://www.rabbitmq.com/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     React (
-    <a class="underline hover:no-underline" href="https://reactjs.org/" rel="nofollow">
+    <a href="https://reactjs.org/" rel="nofollow">
      https://reactjs.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     React Native (
-    <a class="underline hover:no-underline" href="https://reactnative.dev/" rel="nofollow">
+    <a href="https://reactnative.dev/" rel="nofollow">
      https://reactnative.dev/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Script.aculo.us (
-    <a class="underline hover:no-underline" href="https://script.aculo.us/" rel="nofollow">
+    <a href="https://script.aculo.us/" rel="nofollow">
      https://script.aculo.us/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Terraform (
-    <a class="underline hover:no-underline" href="https://www.terraform.io/" rel="nofollow">
+    <a href="https://www.terraform.io/" rel="nofollow">
      https://www.terraform.io/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Traefik (
-    <a class="underline hover:no-underline" href="https://traefik.io/" rel="nofollow">
+    <a href="https://traefik.io/" rel="nofollow">
      https://traefik.io/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     VueJS (
-    <a class="underline hover:no-underline" href="https://vuejs.org/" rel="nofollow">
+    <a href="https://vuejs.org/" rel="nofollow">
      https://vuejs.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Webpack (
-    <a class="underline hover:no-underline" href="https://webpack.js.org/" rel="nofollow">
+    <a href="https://webpack.js.org/" rel="nofollow">
      https://webpack.js.org/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Zend Framework 1 (
-    <a class="underline hover:no-underline" href="https://github.com/zendframework/zf1" rel="nofollow">
+    <a href="https://github.com/zendframework/zf1" rel="nofollow">
      https://github.com/zendframework/zf1
     </a>
     )
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="anderes">
+  <p>
+   <br/>
+  </p>
+  <h3 id="anderes">
    Anderes
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     OMR - Online Marketing Rockstars (
-    <a class="underline hover:no-underline" href="https://omr.com/de/" rel="nofollow">
+    <a href="https://omr.com/de/" rel="nofollow">
      https://omr.com/de/
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     No Code (
-    <a class="underline hover:no-underline" href="https://www.nocode.tech/" rel="nofollow">
+    <a href="https://www.nocode.tech/" rel="nofollow">
      https://www.nocode.tech/
     </a>
     )
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-personen">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-personen">
    Erwähnte Personen
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Matthias Endler (
-    <a class="underline hover:no-underline" href="https://twitter.com/matthiasendler" rel="nofollow">
+    <a href="https://twitter.com/matthiasendler" rel="nofollow">
      https://twitter.com/matthiasendler
     </a>
     /
-    <a class="underline hover:no-underline" href="https://endler.dev/" rel="nofollow">
+    <a href="https://endler.dev/" rel="nofollow">
      https://endler.dev/
     </a>
     )
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Anfragen an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
   </p>

--- a/src/pages/podcast/episode/03-over-engineering-das-werkzeug-des-teufels.md
+++ b/src/pages/podcast/episode/03-over-engineering-das-werkzeug-des-teufels.md
@@ -65,189 +65,204 @@ title: '#03 Over-Engineering, das Werkzeug des Teufels?'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Was ist eigentlich Over-Engineering? Und wann ist es einfach nur gutes Engineering? Ist das eigentlich immer nur negativ? Oder auch mal positiv? Gibt es auch Under-Engineering? In dieser Episode philosophieren Andy und Wolfgang darüber, wann der Drang nach dem perfekten Source-Code Overenegineering ist und warum es in der akademischen Welt nur dreckig programmiert wird.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum Wolfgang seine Kletterschuhe nach Tschechien sendet
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Andy (
-   <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <a href="https://twitter.com/andygrunwald" rel="nofollow">
     https://twitter.com/andygrunwald
    </a>
    ) und Wolfgang (
-   <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+   <a href="https://twitter.com/schafele" rel="nofollow">
     https://twitter.com/schafele
    </a>
    ) sprechen im Detail über
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:25) Was ist Over-Engineering?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:20) Umfeld vom Over-Engineering und die Anforderungen vom Projekt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:15) Ist alter Source-Code Over- oder Underengineered?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (09:00) Leiden Akademiker mehr unter Over-Engineering?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (10:10) Wann weiß ich, ob ich etwas mehr Arbeit in ein Projekt stecken soll?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (11:50) Ist die meiste Java-Software Over-Engineered?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:55) Kann man nicht mit alles einfach dreckig starten?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (14:40) Neue Technologie vs. das was ich schon kenne
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (17:55) Twitter-Umfrage, was Leute unter Over-Engineering verstehen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:50) Das DRY-Prinzip
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:15) Ein ORM / Object-Relational Mapping
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (28:12) Dependency Injection
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (30:04) Hackernews Driven Development
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (33:20) Positives Over-Engineering
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (35:15) Methoden um sich selbst vor dem Over-Engineering zu schützen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (37:30) Wolfgang's Glaskugel
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (38:07) Overengineering findet viel zu selten statt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (41:55) Bei Google steht ein staubiger Server im Datacenter, der die Suchmaschine betreibt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (45:23) Underengineering bei der Reparatur von Kletterschuhen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (46:40) Do things that don’t scale - Wie startet man ein Projekt möglichst einfach
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (47:55) Over-Engineering in der Automation
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (48:35) Fazit
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (50:20) Kontakt und Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="artikel">
+  <h3 id="artikel">
    Artikel
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Do things that don't scale von Paul Graham:
-    <a class="underline hover:no-underline" href="http://paulgraham.com/ds.html" rel="nofollow">
+    <a href="http://paulgraham.com/ds.html" rel="nofollow">
      http://paulgraham.com/ds.html
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Hackernews Driven Development:
-    <a class="underline hover:no-underline" href="https://devdriven.by/hn/" rel="nofollow">
+    <a href="https://devdriven.by/hn/" rel="nofollow">
      https://devdriven.by/hn/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Byte Shifting:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Bitweiser_Operator" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/Bitweiser_Operator" rel="nofollow">
      https://de.wikipedia.org/wiki/Bitweiser_Operator
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="konzepte">
+  <p>
+   <br/>
+  </p>
+  <h3 id="konzepte">
    Konzepte
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     You Aren’t Gonna Need It (YAGNI):
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/YAGNI" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/YAGNI" rel="nofollow">
      https://de.wikipedia.org/wiki/YAGNI
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Don’t repeat yourself (DRY):
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Don%E2%80%99t_repeat_yourself" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/Don%E2%80%99t_repeat_yourself" rel="nofollow">
      https://de.wikipedia.org/wiki/Don%E2%80%99t_repeat_yourself
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="projekte">
+  <p>
+   <br/>
+  </p>
+  <h3 id="projekte">
    Projekte
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Hackernews:
-    <a class="underline hover:no-underline" href="https://news.ycombinator.com/" rel="nofollow">
+    <a href="https://news.ycombinator.com/" rel="nofollow">
      https://news.ycombinator.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     JavaScript library "left-pad":
-    <a class="underline hover:no-underline" href="https://www.npmjs.com/package/left-pad" rel="nofollow">
+    <a href="https://www.npmjs.com/package/left-pad" rel="nofollow">
      https://www.npmjs.com/package/left-pad
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Terraform:
-    <a class="underline hover:no-underline" href="https://www.terraform.io/" rel="nofollow">
+    <a href="https://www.terraform.io/" rel="nofollow">
      https://www.terraform.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     HashiCorp configuration language:
-    <a class="underline hover:no-underline" href="https://github.com/hashicorp/hcl" rel="nofollow">
+    <a href="https://github.com/hashicorp/hcl" rel="nofollow">
      https://github.com/hashicorp/hcl
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Go / Golang:
-    <a class="underline hover:no-underline" href="https://go.dev/" rel="nofollow">
+    <a href="https://go.dev/" rel="nofollow">
      https://go.dev/
     </a>
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Anfragen an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
   </p>

--- a/src/pages/podcast/episode/04-lohnt-der-einstieg-in-open-source.md
+++ b/src/pages/podcast/episode/04-lohnt-der-einstieg-in-open-source.md
@@ -75,278 +75,305 @@ title: '#04 Lohnt der Einstieg in Open Source?'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Für Andy ist Open Source und die Open Source Community ist bereits ein langer und essentieller Begleiter. In dieser Episode interviewed Wolfgang Andy genau zu dieseme Thema: Wie war sein Einsteig? Wieso es wichtig ist, sich Zeit zu nehmen um ein Bug-Ticket zu schreiben und was Snowboarden mit Open Source zu tun hat.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Wie man Andy dazu bringt, nackig durch die Wohnung zu flitzen.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Andy (
-   <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <a href="https://twitter.com/andygrunwald" rel="nofollow">
     https://twitter.com/andygrunwald
    </a>
    ) und Wolfgang (
-   <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+   <a href="https://twitter.com/schafele" rel="nofollow">
     https://twitter.com/schafele
    </a>
    ) sprechen im Detail über:
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (2:04) Wann hast du mit Open Source begonnen und warum?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:27) Wie würdest du denn Open Source definieren?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:08) Warum bist du in der Open Source Szene geblieben?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:45) Hattest du mal schlechte Erlebnisse bei oder mit Open Source? als Maintainer?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:33) ... und als Contributor?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:15) Welche Tips kannst du Contributoren geben, um die Erfolgschancen für Pull Requests zu erhöhen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (10:04) Hast du Best Practices aus Maintainer-Seite, wie man mit Contributoren umgeht?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:12) Wie geht man mit eigenen Open Source Projekten um, die man selbst nicht mehr nutzt?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (15:31) Wie gehst du mit Feature Requests um?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (17:56) Hat dir bereits jemand ein Feature gesponsored?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (19:14) Open Source wird als Free work verstanden
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:45) Tipps für einen Feature Request bei einem Projekt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:49) Kommunikation ist sehr wichtig
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (22:36) Wie siehst du den Stellenwert von Open Source im professionellem Umfeld?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (24:35) Open Source als Mittel fürs Recruiting
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:40) Wie kann sich eine kleine Firma im Open Source Bereich engagieren?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (28:09) Was hälst du von dem Open Source First Konzept?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (29:29) Was ist Inner Source?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (30:40) Passwörter und Secrets im Code
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (32:12) Möglichkeiten um ein Repository zu Open Sourcen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (32:38) Negative Punkte für den Einsatz von Open Source
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (36:55) Welche Open Source Lizenz würdest du empfehlen, wenn jemand mit einem neuen Projekt starten möchte?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (39:29) Projekte auf GitHub ohne Lizenz
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (40:35) Beer- und Pizza-Lizenz
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (41:02) Kleine Sponsoring-Beiträge und Danke-Nachrichten können viel bewirken
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (45:13) Andy flitzt nackig durch die Wohnung
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (48:15) Was deine Open Source Contribution mit deinem professionellen Werdegang zu tun hat
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-artikel">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-artikel">
    Erwähnte Artikel
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     "Choose an open source license" von GitHub:
-    <a class="underline hover:no-underline" href="https://choosealicense.com/" rel="nofollow">
+    <a href="https://choosealicense.com/" rel="nofollow">
      https://choosealicense.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     "Scaling from 2,000 to 25,000 engineers on GitHub at Microsoft" von Jeff Wilcox:
-    <a class="underline hover:no-underline" href="https://www.jeff.wilcox.name/2019/06/scaling-25k/" rel="nofollow">
+    <a href="https://www.jeff.wilcox.name/2019/06/scaling-25k/" rel="nofollow">
      https://www.jeff.wilcox.name/2019/06/scaling-25k/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     "Für 50 Prozent der Entwickler ist Open Source ein 9-to-5-Job":
-    <a class="underline hover:no-underline" href="https://www.techrepublic.com/article/for-50-percent-of-developers-open-source-is-a-9-to-5-job/" rel="nofollow">
+    <a href="https://www.techrepublic.com/article/for-50-percent-of-developers-open-source-is-a-9-to-5-job/" rel="nofollow">
      https://www.techrepublic.com/article/for-50-percent-of-developers-open-source-is-a-9-to-5-job/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     "BMW *are* complying with the GPL" von Terence Eden: https://shkspr.mobi/blog/2016/03/bmw-are-complying-with-the-gpl/
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-personen">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-personen">
    Erwähnte Personen
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Richard Stallman:
-    <a class="underline hover:no-underline" href="https://stallman.org/" rel="nofollow">
+    <a href="https://stallman.org/" rel="nofollow">
      https://stallman.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Daniel Stenberg:
-    <a class="underline hover:no-underline" href="https://daniel.haxx.se/" rel="nofollow">
+    <a href="https://daniel.haxx.se/" rel="nofollow">
      https://daniel.haxx.se/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-projekte">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-projekte">
    Erwähnte Projekte
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     curl:
-    <a class="underline hover:no-underline" href="https://curl.se/" rel="nofollow">
+    <a href="https://curl.se/" rel="nofollow">
      https://curl.se/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     wolfSSL:
-    <a class="underline hover:no-underline" href="https://www.wolfssl.com/" rel="nofollow">
+    <a href="https://www.wolfssl.com/" rel="nofollow">
      https://www.wolfssl.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Wolfgangs Doku-Wiki Plugin:
-    <a class="underline hover:no-underline" href="https://github.com/woolfg/dokuwiki-plugin-gitbacked" rel="nofollow">
+    <a href="https://github.com/woolfg/dokuwiki-plugin-gitbacked" rel="nofollow">
      https://github.com/woolfg/dokuwiki-plugin-gitbacked
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Gerrit Code Review:
-    <a class="underline hover:no-underline" href="https://www.gerritcodereview.com/" rel="nofollow">
+    <a href="https://www.gerritcodereview.com/" rel="nofollow">
      https://www.gerritcodereview.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     TYPO3:
-    <a class="underline hover:no-underline" href="https://typo3.org/" rel="nofollow">
+    <a href="https://typo3.org/" rel="nofollow">
      https://typo3.org/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-events">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-events">
    Erwähnte Events
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     TYPO3 Snowboard Tour:
-    <a class="underline hover:no-underline" href="https://t3board.typo3.org/" rel="nofollow">
+    <a href="https://t3board.typo3.org/" rel="nofollow">
      https://t3board.typo3.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     FOSDEM:
-    <a class="underline hover:no-underline" href="https://fosdem.org/2022/" rel="nofollow">
+    <a href="https://fosdem.org/2022/" rel="nofollow">
      https://fosdem.org/2022/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-lizenzen">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-lizenzen">
    Erwähnte Lizenzen
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Bier-Lizenz:
-    <a class="underline hover:no-underline" href="https://fedoraproject.org/wiki/Licensing/Beerware" rel="nofollow">
+    <a href="https://fedoraproject.org/wiki/Licensing/Beerware" rel="nofollow">
      https://fedoraproject.org/wiki/Licensing/Beerware
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Pizza-Lizenz:
-    <a class="underline hover:no-underline" href="https://github.com/PumaConcolor/pizza-license" rel="nofollow">
+    <a href="https://github.com/PumaConcolor/pizza-license" rel="nofollow">
      https://github.com/PumaConcolor/pizza-license
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Do What the Fuck You Want to Public Lizenz:
-    <a class="underline hover:no-underline" href="http://www.wtfpl.net/" rel="nofollow">
+    <a href="http://www.wtfpl.net/" rel="nofollow">
      http://www.wtfpl.net/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     MIT Lizenz:
-    <a class="underline hover:no-underline" href="https://opensource.org/licenses/MIT" rel="nofollow">
+    <a href="https://opensource.org/licenses/MIT" rel="nofollow">
      https://opensource.org/licenses/MIT
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     BSD Lizenz:
-    <a class="underline hover:no-underline" href="https://opensource.org/licenses/BSD-3-Clause" rel="nofollow">
+    <a href="https://opensource.org/licenses/BSD-3-Clause" rel="nofollow">
      https://opensource.org/licenses/BSD-3-Clause
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Apache 2.0 Lizenz:
-    <a class="underline hover:no-underline" href="https://www.apache.org/licenses/LICENSE-2.0" rel="nofollow">
+    <a href="https://www.apache.org/licenses/LICENSE-2.0" rel="nofollow">
      https://www.apache.org/licenses/LICENSE-2.0
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Anfragen an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
   </p>

--- a/src/pages/podcast/episode/05-team-lead-der-einzige-ausweg.md
+++ b/src/pages/podcast/episode/05-team-lead-der-einzige-ausweg.md
@@ -53,151 +53,166 @@ title: '#05 Team Lead - der einzige Ausweg'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Engineering Manager oder Team-Lead: Eine Position die sehr motivierend, aber auch abschreckend wirken kann.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Was erwartet einen? Was ist die Aufgabe einer Engineering Managerin? Wie verändert sich der Arbeitsalltag? Ist die Stelle überhaupt etwas für mich? Und was passiert, wenn ich doch lieber Software Entwickeln möchte? Gibt es einen alternativen Karrierepfad?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    All das und noch über viel mehr Erfahrungen sprechen Andy und Wolfgang in Episode 05 vom Engineering Kiosk.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum Andy Muskelkater im Arsch hat
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-artikel">
+  <h3 id="erwahnte-artikel">
    Erwähnte Artikel
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Mitchell's New Role at HashiCorp:
-    <a class="underline hover:no-underline" href="https://www.hashicorp.com/blog/mitchell-s-new-role-at-hashicorp" rel="nofollow">
+    <a href="https://www.hashicorp.com/blog/mitchell-s-new-role-at-hashicorp" rel="nofollow">
      https://www.hashicorp.com/blog/mitchell-s-new-role-at-hashicorp
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Tom Bartel mit "A Year Ago, I Stepped Away From a Leadership Position. Here Are 7 Things I Learned From That":
-    <a class="underline hover:no-underline" href="https://www.tombartel.me/blog/leadership-position-to-individual-contributor-what-i-learned/" rel="nofollow">
+    <a href="https://www.tombartel.me/blog/leadership-position-to-individual-contributor-what-i-learned/" rel="nofollow">
      https://www.tombartel.me/blog/leadership-position-to-individual-contributor-what-i-learned/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     "What is a Staff (or Staff-Plus or Principal) Engineer?":
-    <a class="underline hover:no-underline" href="https://mikemcquaid.com/2021/10/01/what-is-a-staff-plus-principal-engineer/" rel="nofollow">
+    <a href="https://mikemcquaid.com/2021/10/01/what-is-a-staff-plus-principal-engineer/" rel="nofollow">
      https://mikemcquaid.com/2021/10/01/what-is-a-staff-plus-principal-engineer/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="bucher-uber-das-engineering-management">
+  <p>
+   <br/>
+  </p>
+  <h3 id="bucher-uber-das-engineering-management">
    Bücher über das Engineering Management
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     "The Managers Path" von Camille Fournier
    </li>
-   <li class="mb-3">
+   <li>
     "Turn the ship around" oder "Reiß das Ruder rum!" von David Marquet
    </li>
-   <li class="mb-3">
+   <li>
     "Drive" von Daniel H. Pink
    </li>
-   <li class="mb-3">
+   <li>
     "Start with Why" von Simon Sinek
    </li>
-   <li class="mb-3">
+   <li>
     "High Output Management" von Andrew S. Grove
    </li>
-   <li class="mb-3">
+   <li>
     "An elegant puzzle" von Will Larson
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:55) Hörer Feedback
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:43) Wann bist du das erste mal in eine Teamlead-Stelle gerutscht?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:15) Kann man bereits Aufgaben eines Teamleads übernehmen, ohne ein Teamlead zu sein?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (04:18) Wie viel Zeit hast du mit Hands-On und wie viel mit People Management verbracht?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (04:52) Wie lang warst du Individual Contributor bevor du Teamleiter wurdest?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:42) Was hat sich am meisten an deinem Arbeitsalltag geändert?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (09:22) Was ist ein 1 on 1 Meeting und warum ist dies sinnvoll?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (13:27) Was ist eine gute Teamgröße für den Start als Engineering Manager?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (14:50) Woher wusstest du, was du als neuer Engineering Manager machen musst?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:51) Empfehlungen um die Entscheidung "Möchte ich den Job einer Engineering Managerin machen?" treffen zu können
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (24:25) Feedback-Loop eines Software Engineers und eines Engineering Managers
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:50) Was solltest du nicht wollen, wenn du ein Engineering Manager werden möchtest?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (27:42) Ist es ab und zu notwendig, seine eigene Entscheidung im Team durchzusetzen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (28:36) Schwierige Konversationen als Engineering Manager
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (30:49) Ist es ein Rückschritt wenn man als Engineering Manager zurück zum Software Engineer wechselt?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (34:42) Wie sieht ein möglicher Karriereweg aus, wenn der Engineering Manager-Weg nichts für mich ist?
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/06-hype-oder-hope-job-titel-und-beförderungen.md
+++ b/src/pages/podcast/episode/06-hype-oder-hope-job-titel-und-beförderungen.md
@@ -43,160 +43,175 @@ title: "#06 Hype oder Hope: Job-Titel und Bef\xF6rderungen"
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Sind Machine Learning und Artificial Intelligence nur Hypes oder sollte ich meine Karriere dahingehend ausrichten? Und welche Hypes gibt es im Infrastruktur-Bereich? Und überhaupt: Wie steht das alles im Zusammenhang mit Job-Titels, meiner Beförderung zum Senior Engineer und meinem Gehalt?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    All diese Themen klären Wolfgang und Andy in dieser wilden Folge. Weiterhin: Warum das Leben kein Ponyhof ist, was Agrar-Tech und autonom-fahrende Trecker, die Inflation und Krösus damit zu tun haben, sowie warum Software Engineers zu den Top 5% der Gesellschaft gehören.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum Wolfgang kein Eiskunstlauf macht und wie er seinen Dr.-Titel bekommen hat.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     DeepMind AlphaCode:
-    <a class="underline hover:no-underline" href="https://www.deepmind.com/blog/article/Competitive-programming-with-AlphaCode" rel="nofollow">
+    <a href="https://www.deepmind.com/blog/article/Competitive-programming-with-AlphaCode" rel="nofollow">
      https://www.deepmind.com/blog/article/Competitive-programming-with-AlphaCode
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     GitHub Co-Pilot:
-    <a class="underline hover:no-underline" href="https://copilot.github.com/" rel="nofollow">
+    <a href="https://copilot.github.com/" rel="nofollow">
      https://copilot.github.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     GPT-3 Model:
-    <a class="underline hover:no-underline" href="https://en.wikipedia.org/wiki/GPT-3" rel="nofollow">
+    <a href="https://en.wikipedia.org/wiki/GPT-3" rel="nofollow">
      https://en.wikipedia.org/wiki/GPT-3
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Engineering levels / levels.fyi:
-    <a class="underline hover:no-underline" href="https://www.levels.fyi/?compare=Google%2CFacebook%2CMicrosoft&amp;track=Software+Engineer" rel="nofollow">
+    <a href="https://www.levels.fyi/?compare=Google%2CFacebook%2CMicrosoft&amp;track=Software+Engineer" rel="nofollow">
      https://www.levels.fyi/?compare=Google,Facebook,Microsoft&amp;track=Software%20Engineer
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Down-Leveling = The Senioritz Rollercoaster:
-    <a class="underline hover:no-underline" href="https://newsletter.pragmaticengineer.com/p/the-seniority-rollercoaster" rel="nofollow">
+    <a href="https://newsletter.pragmaticengineer.com/p/the-seniority-rollercoaster" rel="nofollow">
      https://newsletter.pragmaticengineer.com/p/the-seniority-rollercoaster
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Krösus:
-    <a class="underline hover:no-underline" href="https://de.wiktionary.org/wiki/Kr%C3%B6sus" rel="nofollow">
+    <a href="https://de.wiktionary.org/wiki/Kr%C3%B6sus" rel="nofollow">
      https://de.wiktionary.org/wiki/Kr%C3%B6sus
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Career ladders bei Firmen / progression.fyi:
-    <a class="underline hover:no-underline" href="https://www.progression.fyi/" rel="nofollow">
+    <a href="https://www.progression.fyi/" rel="nofollow">
      https://www.progression.fyi/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     CircleCI Engineering Competency Matrix:
-    <a class="underline hover:no-underline" href="https://docs.google.com/spreadsheets/d/131XZCEb8LoXqy79WWrhCX4sBnGhCM1nAIz4feFZJsEo/edit#gid=0" rel="nofollow">
+    <a href="https://docs.google.com/spreadsheets/d/131XZCEb8LoXqy79WWrhCX4sBnGhCM1nAIz4feFZJsEo/edit#gid=0" rel="nofollow">
      https://docs.google.com/spreadsheets/d/131XZCEb8LoXqy79WWrhCX4sBnGhCM1nAIz4feFZJsEo/edit#gid=0
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-personen">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-personen">
    Erwähnte Personen
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Russ Cox:
-    <a class="underline hover:no-underline" href="https://swtch.com/~rsc/" rel="nofollow">
+    <a href="https://swtch.com/~rsc/" rel="nofollow">
      https://swtch.com/~rsc/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:06) Deepmind News "AlphaCode" - Ein neuer Machine Learning Hype?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:40) Wie kann Alpha Code in der Praxis genutzt werden?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:04) Coding Challenges im Recruiting-Prozess
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (11:09) Hypes im Infrastruktur-Bereich
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (16:45) Frischer Wind von neuen Leuten in der Firma
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (19:22) Mono-Repos als Hype-Beispiel
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:55) Industrie-Definition von Job-Titles
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (26:03) Braucht man Job-Titles (Senior, etc.)?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (31:43) Festgefahrene Strukturen in Konzernen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (37:38) Geld ist bei weitem nicht alles bei einem Job
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (41:50) Mach das was dir Spaß machst und Generalisten vs. Spezialisten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (45:36) 5-Jahres-Pläne
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (49:56) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/07-die-freelance-freiheit.md
+++ b/src/pages/podcast/episode/07-die-freelance-freiheit.md
@@ -61,163 +61,263 @@ title: '#07 Die Freelance Freiheit'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Sein eigener Chef zu sein, sich die Projekte aussuchen können und sich die Zeit frei selbst einzuteilen. Obendrein noch einen Haufen Geld verdienen. Das ist die Vorstellung von vielen ITlern zur Selbstständigkeit. Doch wie sieht die Realität aus? Was sind die negativen Aspekte? Und wie viel Geld kommt wirklich unterm Strich bei rum?
+<p>
+   <span>
+    Sein eigener Chef zu sein, sich die Projekte aussuchen können und sich die Zeit frei selbst einzuteilen. Obendrein noch einen Haufen Geld verdienen. Das ist die Vorstellung von vielen ITlern zur Selbstständigkeit. Doch wie sieht die Realität aus? Was sind die negativen Aspekte? Und wie viel Geld kommt wirklich unterm Strich bei rum?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   In dieser Episode teilt Wolfgang seine langjährige Freelance-Erfahrung: Welche Arten von Freelancing gibt es, wie er die Probleme beim Schätzen des zeitlichen Aufwandes umgeht, warum rostende Software ein Problem ist und zu schlecht gelaunten Kunden führt, ob es sich lohnt seine Finger zu versicherung und was goldene Handschellen mit all dem zu tun haben.
+  <p>
+   <span>
+    In dieser Episode teilt Wolfgang seine langjährige Freelance-Erfahrung: Welche Arten von Freelancing gibt es, wie er die Probleme beim Schätzen des zeitlichen Aufwandes umgeht, warum rostende Software ein Problem ist und zu schlecht gelaunten Kunden führt, ob es sich lohnt seine Finger zu versicherung und was goldene Handschellen mit all dem zu tun haben.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Bonus: Wie Wolfgang einen Kunden beim Krafttraining im Fitnessstudio akquiriert hat, ohne selbst Gewichte zu stemmen.
+  <p>
+   <span>
+    Bonus: Wie Wolfgang einen Kunden beim Krafttraining im Fitnessstudio akquiriert hat, ohne selbst Gewichte zu stemmen.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Feedback an
+   </span>
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Freelancer Stundensätze:
-    <a class="underline hover:no-underline" href="https://www.gulp.de/stundensatzkalkulator" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Freelancer Stundensätze:
+    </span>
+    <a href="https://www.gulp.de/stundensatzkalkulator" rel="nofollow">
      GULP Stundensatz Kalkulator
     </a>
    </li>
-   <li class="mb-3">
-    Freelancer Vermittlungsplattformen
+   <li>
+    <span>
+     Freelancer Vermittlungsplattformen
+    </span>
    </li>
-   <li class="mb-3">
-    Freelancermap:
-    <a class="underline hover:no-underline" href="https://www.freelancermap.de/" rel="nofollow">
+   <li>
+    <span>
+     Freelancermap:
+    </span>
+    <a href="https://www.freelancermap.de/" rel="nofollow">
      https://www.freelancermap.de/
     </a>
    </li>
-   <li class="mb-3">
-    Gulp:
-    <a class="underline hover:no-underline" href="https://www.gulp.de" rel="nofollow">
+   <li>
+    <span>
+     Gulp:
+    </span>
+    <a href="https://www.gulp.de" rel="nofollow">
      https://www.gulp.de
     </a>
    </li>
-   <li class="mb-3">
-    Hays:
-    <a class="underline hover:no-underline" href="https://www.hays.de" rel="nofollow">
+   <li>
+    <span>
+     Hays:
+    </span>
+    <a href="https://www.hays.de" rel="nofollow">
      https://www.hays.de
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="anderes">
+  <p>
+   <br/>
+  </p>
+  <h3 id="anderes">
    Anderes
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Als Kleinunternehmer im Sinne von § 19 Abs. 1 UStG wird Umsatzsteuer nicht berechnet. (in Deutschland)
+  <ul>
+   <li>
+    <span>
+     Als Kleinunternehmer im Sinne von § 19 Abs. 1 UStG wird Umsatzsteuer nicht berechnet. (in Deutschland)
+    </span>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00:00) Intro
+  <p>
+   <span>
+    (00:00:00) Intro
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00:45) Bier holen
+  <p>
+   <span>
+    (00:00:45) Bier holen
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:01:43) Wolfgangs erstes Freelancing-Projekt
+  <p>
+   <span>
+    (00:01:43) Wolfgangs erstes Freelancing-Projekt
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:02:54) Weibliche Software-Engineering Freelancer
+  <p>
+   <span>
+    (00:02:54) Weibliche Software-Engineering Freelancer
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:03:45) Wie Wolfgang zum Freelancing gekommen ist
+  <p>
+   <span>
+    (00:03:45) Wie Wolfgang zum Freelancing gekommen ist
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:05:17) Verschiedene Arten vom Freelancing
+  <p>
+   <span>
+    (00:05:17) Verschiedene Arten vom Freelancing
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:08:19) Freelancing als Lösung für Remote Work
+  <p>
+   <span>
+    (00:08:19) Freelancing als Lösung für Remote Work
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:10:16) Scheinselbstständigkeit
+  <p>
+   <span>
+    (00:10:16) Scheinselbstständigkeit
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:11:13) Entwicklung der Freelancing-Arbeit anhand deiner Erfahrung
+  <p>
+   <span>
+    (00:11:13) Entwicklung der Freelancing-Arbeit anhand deiner Erfahrung
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:14:14) Software Maintenance bei Freelancing-Projekten
+  <p>
+   <span>
+    (00:14:14) Software Maintenance bei Freelancing-Projekten
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:17:40) Was sind die positiven Aspekte des Freelancings?
+  <p>
+   <span>
+    (00:17:40) Was sind die positiven Aspekte des Freelancings?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:27:28) Was sind die negativen Seiten vom Freelancen?
+  <p>
+   <span>
+    (00:27:28) Was sind die negativen Seiten vom Freelancen?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:28:25) Kundenakquise
+  <p>
+   <span>
+    (00:28:25) Kundenakquise
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:29:44) Preisfindung
+  <p>
+   <span>
+    (00:29:44) Preisfindung
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:37:00) Wie geht man die Selbstständigkeit an? Wie setze ich es in der Praxis um?
+  <p>
+   <span>
+    (00:37:00) Wie geht man die Selbstständigkeit an? Wie setze ich es in der Praxis um?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:40:42) Steuerberater
+  <p>
+   <span>
+    (00:40:42) Steuerberater
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:46:09) Welche Kosten kommen noch auf einen zu?
+  <p>
+   <span>
+    (00:46:09) Welche Kosten kommen noch auf einen zu?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:48:21) Haftung und was eine GmbH für dich tun kann
+  <p>
+   <span>
+    (00:48:21) Haftung und was eine GmbH für dich tun kann
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:50:11) Geschäftskonten
+  <p>
+   <span>
+    (00:50:11) Geschäftskonten
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:51:18) Der Start ist schwer und Weiterempfehlungen
+  <p>
+   <span>
+    (00:51:18) Der Start ist schwer und Weiterempfehlungen
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:54:29) Fragen, um herauszufinden, ob die Selbstständigkeit etwas für mich ist
+  <p>
+   <span>
+    (00:54:29) Fragen, um herauszufinden, ob die Selbstständigkeit etwas für mich ist
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:59:56) Neben der Festanstellung starten
+  <p>
+   <span>
+    (00:59:56) Neben der Festanstellung starten
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (01:02:12) Outro﻿
+  <p>
+   <span>
+    (01:02:12) Outro
+    <span>
+     ﻿
+    </span>
+   </span>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Wolfgang Gassler (
+    </span>
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
-   <li class="mb-3">
-    Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <li>
+    <span>
+     Andy Grunwald (
+    </span>
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Engineering Kiosk Podcast: Anfragen an
+   </span>
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
+   <span>
+   </span>
   </p>

--- a/src/pages/podcast/episode/08-vergiss-doch-datenbanken.md
+++ b/src/pages/podcast/episode/08-vergiss-doch-datenbanken.md
@@ -57,221 +57,233 @@ title: '#08 Vergiss doch Datenbanken!'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Datenbanken, besonders relationale Datenbanken und im Web ganz besonders MySQL.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Jeder kennt sie, jeder nutzt sie, aber keiner gibt zu diese zu nutzen da sie uncool und alt sind und sowieso nicht skalieren.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Wolfgang und Andy sprechen ein wenig über dieses Thema: Wie man seine eigene SQL Datenbank schreibt, was der Unterschied von Row-Based und Statement-Based Replication ist, warum simple Dateien oft besser sind als eine Datenbank, ob sqlite helfen kann und MongoDB die Lösung ist, wie Facebook, Booking und GitHub MySQL betreiben, ob PostgreSQL wirklich was kann und welche Schritte ihr unternehmen könnt, um eure Datenbank zu tunen.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Ob Wolfgang Mickey Krause kennt und ob er ein erfolgreicher MySQL Buchautor war.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     SQLProxy:
-    <a class="underline hover:no-underline" href="https://github.com/sysown/proxysql" rel="nofollow">
+    <a href="https://github.com/sysown/proxysql" rel="nofollow">
      https://github.com/sysown/proxysql
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Vitess:
-    <a class="underline hover:no-underline" href="https://vitess.io/" rel="nofollow">
+    <a href="https://vitess.io/" rel="nofollow">
      https://vitess.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Building for the 99% Developers:
-    <a class="underline hover:no-underline" href="https://future.a16z.com/software-development-building-for-99-developers/" rel="nofollow">
+    <a href="https://future.a16z.com/software-development-building-for-99-developers/" rel="nofollow">
      https://future.a16z.com/software-development-building-for-99-developers/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Litestream:
-    <a class="underline hover:no-underline" href="https://litestream.io/" rel="nofollow">
+    <a href="https://litestream.io/" rel="nofollow">
      https://litestream.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Designing Data-intensive Applications:
-    <a class="underline hover:no-underline" href="https://dataintensive.net/" rel="nofollow">
+    <a href="https://dataintensive.net/" rel="nofollow">
      https://dataintensive.net/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     MyRocks Storage Engine:
-    <a class="underline hover:no-underline" href="http://myrocks.io/" rel="nofollow">
+    <a href="http://myrocks.io/" rel="nofollow">
      http://myrocks.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     MySQL 8.0: The end of MyISAM:
-    <a class="underline hover:no-underline" href="https://www.percona.com/blog/2016/10/11/mysql-8-0-end-myisam/" rel="nofollow">
+    <a href="https://www.percona.com/blog/2016/10/11/mysql-8-0-end-myisam/" rel="nofollow">
      https://www.percona.com/blog/2016/10/11/mysql-8-0-end-myisam/
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele/status/1200180440184827904" rel="nofollow">
+   <li>
+    <a href="https://twitter.com/schafele/status/1200180440184827904" rel="nofollow">
      Wolfgang’s Talk: Forget Databases, use files!
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://fosdem.org/2022/schedule/event/efficient_mysql/" rel="nofollow">
+   <li>
+    <a href="https://fosdem.org/2022/schedule/event/efficient_mysql/" rel="nofollow">
      Efficient MySQL Performance Talk mit Video
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://web.archive.org/web/20120303090458/http://dbis-informatik.uibk.ac.at/188-0-VO-Arch---Impl--von-DBS.html" rel="nofollow">
+   <li>
+    <a href="https://web.archive.org/web/20120303090458/http://dbis-informatik.uibk.ac.at/188-0-VO-Arch---Impl--von-DBS.html" rel="nofollow">
      Gruß aus der Vergangenheit, Wolfi’s Lehrveranstaltung Datenbankimplementierung (2011)
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://dev.mysql.com/doc/refman/5.7/en/replication-features-functions.html" rel="nofollow">
+   <li>
+    <a href="https://dev.mysql.com/doc/refman/5.7/en/replication-features-functions.html" rel="nofollow">
      NOW() und Time Funktionen bei Statement Based Replication in MySQL
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Percona Config Wizard
-    <a class="underline hover:no-underline" href="https://www.percona.com/blog/2019/04/22/end-of-life-query-analyzer-and-mysql-configuration-generator/" rel="nofollow">
+    <a href="https://www.percona.com/blog/2019/04/22/end-of-life-query-analyzer-and-mysql-configuration-generator/" rel="nofollow">
      wurde leider eingestellt
     </a>
     aber alternativ kann MySQL Tuner
-    <a class="underline hover:no-underline" href="https://www.linode.com/docs/guides/how-to-optimize-mysql-performance-using-mysqltuner/" rel="nofollow">
+    <a href="https://www.linode.com/docs/guides/how-to-optimize-mysql-performance-using-mysqltuner/" rel="nofollow">
      https://www.linode.com/docs/guides/how-to-optimize-mysql-performance-using-mysqltuner/
     </a>
     verwendet werden
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="erwahnte-personen">
+  <p>
+   <br/>
+  </p>
+  <h3 id="erwahnte-personen">
    Erwähnte Personen
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Martin Kleppmann
-    <a class="underline hover:no-underline" href="https://martin.kleppmann.com/" rel="nofollow">
+    <a href="https://martin.kleppmann.com/" rel="nofollow">
      https://martin.kleppmann.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Michael Stonebraker:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Michael_Stonebraker" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/Michael_Stonebraker" rel="nofollow">
      https://de.wikipedia.org/wiki/Michael_Stonebraker
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Michael “Monty” Widenius:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Michael_Widenius" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/Michael_Widenius" rel="nofollow">
      https://de.wikipedia.org/wiki/Michael_Widenius
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:15) Wolfgang und Apres-Ski
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:52) Wie programmiert man seine eigene Datenbank?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:24) Was passiert, wenn eine SQL-Query die Datenbank erreicht?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (10:02) Die Schwierigkeiten, wenn man seine eigene Datenbank programmiert
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:35) Sind Dateien besser als Datenbanken?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (18:00) Keine Netzwerk-Verbindungen dank sqlite?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:40) Was ist sqlite?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (22:20) Aussprache von sqlite und SQL und woher es kommt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (23:33) Wie kam MySQL und MariaDB zu ihrem Namen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (24:17) Was empfiehlst du für kleine Apps? MySQL oder sqlite?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:06) Replikation von sqlite Daten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (26:02) Unterschied zwischen Row- und Statement-Based Replication
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (27:56) Wie viel Requests kann man mit einer MySQL-Node bedienen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (29:35) Buchempfehlung: Designing Data-Intensive Application
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (31:42) Was tun, wenn ich Probleme mit MySQL-Performance hab?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (33:16) MySQL bei Facebook
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (36:35) PostgreSQL, der andere Kandidat auf dem Spielfeld
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (38:33) Tooling um MySQL: ProxySQL und Vitess
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (43:38) MySQL Performance-Tipps vom Buch-Autor Wolfgang
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (50:33) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/09-ukraine.md
+++ b/src/pages/podcast/episode/09-ukraine.md
@@ -57,234 +57,246 @@ title: '#09 Ukraine'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Es wird politisch: Der Angriffskrieg auf die Ukraine und eine möglichst technische Beleuchtung des Themas.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Wolfgang und Andy sprechen über die Ukraine und den Angriff durch Russland: Wie haben Tech Konzerne und Firmen reagiert, wie helfen sie ihren Mitarbeiterinnen und Familien. Welche Rolle spielen die GAFA Konzerne und welche Rolle könnten sie spielen. Wie können wir alle helfen und welche Rolle spielen (Miss)informationen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Als kleine Aufmunterung starten wir ein Projekt, das
-   <a class="underline hover:no-underline" href="https://github.com/EngineeringKiosk/OSS-Names" rel="nofollow">
+   <a href="https://github.com/EngineeringKiosk/OSS-Names" rel="nofollow">
     lustige Geschichten
    </a>
    hinter Open-Source Projekten sammelt.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.derstandard.de/story/2000133483085/das-ende-der-stopp-corona-app-ist-da" rel="nofollow">
+  <ul>
+   <li>
+    <a href="https://www.derstandard.de/story/2000133483085/das-ende-der-stopp-corona-app-ist-da" rel="nofollow">
      Österreich schaltet seine Corona-Warn-App ab
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://orf.at/stories/3251387/" rel="nofollow">
+   <li>
+    <a href="https://orf.at/stories/3251387/" rel="nofollow">
      “Militärisch ist Österreich ein neutraler Staat, aber wir sind politisch niemals neutral, wenn es um die Achtung des Völkerrechts geht”
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://zverok.space/blog/2022-03-03-WAR.html" rel="nofollow">
+   <li>
+    <a href="https://zverok.space/blog/2022-03-03-WAR.html" rel="nofollow">
      Hilferuf von Ruby Entwickler
     </a>
     (Blog Post), Tweet: I am not asking you to stop living your comfortable lives [...] I am just asking you to spread the word and show support.
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.bbc.com/news/world-europe-60600487" rel="nofollow">
+   <li>
+    <a href="https://www.bbc.com/news/world-europe-60600487" rel="nofollow">
      Wenn Russen ihren Kindern in der Ukraine oder Ausland nicht glauben
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.doppelgaenger.io/123-big-tech-krisen-pr-%f0%9f%92%a4-ziprecruiter-zoom-zalando-hellofresh-salesforce-sea-ltd/" rel="nofollow">
+   <li>
+    <a href="https://www.doppelgaenger.io/123-big-tech-krisen-pr-%f0%9f%92%a4-ziprecruiter-zoom-zalando-hellofresh-salesforce-sea-ltd/" rel="nofollow">
      Doppelgänger Podcast
     </a>
     : Hintergrund zu Möglichkeiten von Big Tech (
-    <a class="underline hover:no-underline" href="https://www.doppelgaenger.io/123-big-tech-krisen-pr-%f0%9f%92%a4-ziprecruiter-zoom-zalando-hellofresh-salesforce-sea-ltd/" rel="nofollow">
+    <a href="https://www.doppelgaenger.io/123-big-tech-krisen-pr-%f0%9f%92%a4-ziprecruiter-zoom-zalando-hellofresh-salesforce-sea-ltd/" rel="nofollow">
      empfehlenswerter rant von Host Pip
     </a>
     , ersten 30 min),
-    <a class="underline hover:no-underline" href="https://www.doppelgaenger.io/124-%f0%9f%87%ba%f0%9f%87%a6-magic-number-earnings-von-%e2%9d%84%ef%b8%8f-snowflake-%f0%9f%8e%88-plug-power-%f0%9f%a7%9e%e2%99%80%ef%b8%8f-wish-%f0%9f%9a%9b-samsara/" rel="nofollow">
+    <a href="https://www.doppelgaenger.io/124-%f0%9f%87%ba%f0%9f%87%a6-magic-number-earnings-von-%e2%9d%84%ef%b8%8f-snowflake-%f0%9f%8e%88-plug-power-%f0%9f%a7%9e%e2%99%80%ef%b8%8f-wish-%f0%9f%9a%9b-samsara/" rel="nofollow">
      Erfahrungsbericht Aufnahme von Flüchtlinge
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.forbes.com/sites/emmawoollacott/2022/03/02/how-restaurant-reviews-and-tinder-profiles-are-countering-russian-misinformation/" rel="nofollow">
+   <li>
+    <a href="https://www.forbes.com/sites/emmawoollacott/2022/03/02/how-restaurant-reviews-and-tinder-profiles-are-countering-russian-misinformation/" rel="nofollow">
      Crowdstorming mit Tinder und Google maps
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://netzpolitik.org/2012/google-startet-kampagne-gegen-das-leistungsschutzrecht/" rel="nofollow">
+   <li>
+    <a href="https://netzpolitik.org/2012/google-startet-kampagne-gegen-das-leistungsschutzrecht/" rel="nofollow">
      Google wird politisch, auf der Startseite
     </a>
     : jedoch nur in ihrem Interesse bzgl. Leistungsschutzrecht
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.icann.org/en/system/files/correspondence/marby-to-fedorov-02mar22-en.pdf" rel="nofollow">
+   <li>
+    <a href="https://www.icann.org/en/system/files/correspondence/marby-to-fedorov-02mar22-en.pdf" rel="nofollow">
      ICANN Antwort auf Ukrainische Anfrage SSL Zertifikate zu invalidieren
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://blog.pragmaticengineer.com/the-ukraine-crisis-impact-on-tech/" rel="nofollow">
+   <li>
+    <a href="https://blog.pragmaticengineer.com/the-ukraine-crisis-impact-on-tech/" rel="nofollow">
      The Pragmatic engineer
     </a>
     : The Ukraine War - and Its Impact on the Tech Industry
    </li>
-   <li class="mb-3">
+   <li>
     Unterkünfte melden auf
-    <a class="underline hover:no-underline" href="https://www.unterkunft-ukraine.de/" rel="nofollow">
+    <a href="https://www.unterkunft-ukraine.de/" rel="nofollow">
      https://www.unterkunft-ukraine.de/
     </a>
     oder
-    <a class="underline hover:no-underline" href="https://www.airbnb.org/" rel="nofollow">
+    <a href="https://www.airbnb.org/" rel="nofollow">
      https://www.airbnb.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Mehr Informationen und alle Links, um zu Helfen, unter
-    <a class="underline hover:no-underline" href="https://www.zeit.de/zeit-magazin/2022-02/hilfe-ukraine-spenden-deutschland-tipps#gefluechtete-aufnehmen" rel="nofollow">
+    <a href="https://www.zeit.de/zeit-magazin/2022-02/hilfe-ukraine-spenden-deutschland-tipps#gefluechtete-aufnehmen" rel="nofollow">
      https://www.zeit.de/zeit-magazin/2022-02/hilfe-ukraine-spenden-deutschland-tipps
     </a>
     und für Österreich unter
-    <a class="underline hover:no-underline" href="https://www.moment.at/story/ukraine-in-oesterreich-helfen" rel="nofollow">
+    <a href="https://www.moment.at/story/ukraine-in-oesterreich-helfen" rel="nofollow">
      https://www.moment.at/story/ukraine-in-oesterreich-helfen
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://twitter.com/brodnig/status/14%20by99277444372746240" rel="nofollow">
+   <li>
+    <a href="https://twitter.com/brodnig/status/14%20by99277444372746240" rel="nofollow">
      Gute Auflistung von verlässlichen Informationen und gegen Fake News
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.programmier.bar/podcast/news-09-22-tech-sanktionen-gegen-russland-github-advisory-database-google-privacy-sandbox-muzero-google-for-games-developer-summit" rel="nofollow">
+   <li>
+    <a href="https://www.programmier.bar/podcast/news-09-22-tech-sanktionen-gegen-russland-github-advisory-database-google-privacy-sandbox-muzero-google-for-games-developer-summit" rel="nofollow">
      Programmier.bar: Tech News, auch über Russland Sanktionen
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://github.com/EngineeringKiosk/OSS-Names" rel="nofollow">
+   <li>
+    <a href="https://github.com/EngineeringKiosk/OSS-Names" rel="nofollow">
      Der Hintergrund von Open Source Namensgebungen
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.tagesschau.de/wirtschaft/finanzen/mastercard-visa-russland-101.html" rel="nofollow">
+   <li>
+    <a href="https://www.tagesschau.de/wirtschaft/finanzen/mastercard-visa-russland-101.html" rel="nofollow">
      Mastercard und Visa schließen russische Banken aus
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://t3n.de/news/russland-netflix-tiktok-aus-schluss-ende-1457062/" rel="nofollow">
+   <li>
+    <a href="https://t3n.de/news/russland-netflix-tiktok-aus-schluss-ende-1457062/" rel="nofollow">
      Netflix und TikTok ziehen den Stecker in Russland
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://de.airbnb.org/" rel="nofollow">
+   <li>
+    <a href="https://de.airbnb.org/" rel="nofollow">
      airbnb.org - Unterkünfte in Krisenzeiten
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="https://www.unterkunft-ukraine.de/" rel="nofollow">
+   <li>
+    <a href="https://www.unterkunft-ukraine.de/" rel="nofollow">
      unterkunft-ukraine.de
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3>
+   <br/>
+  </h3>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:52) Abgeschlossene Corona-Pandemie in Österreich
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:05) Ukraine-Geschehnisse aus der technischen Perspektive
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:26) Wolfgangs-Sabbatical in der Ukraine
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (04:49) Verbindung der Geschehnisse der Ukraine mit Technologie
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:48) Wie Firmen die Bevölkerung in den entsprechenden Gebieten unterstützen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:50) Männer dürfen zur Zeit die Ukraine nicht verlassen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:58) Große Firmen hätten mehr Power, wenn sie die richtigen Informationen verbreiten würden
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:52) Firmen nutzen die Sanktionen als Marketing-Fall
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (13:42) Sanktionen und wie Firmen agiert haben
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (15:46) Elon Musk und StarLink in der Ukraine
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (17:54) Ukrainische Anfrage an die ICANN zur Abschaltung von dezentraler Infrastruktur
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (20:02) Was könnte Cloudflare tun?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:19) Die Sanktionen treffen auch primär die Zivilbevölkerung
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (22:24) Wie Firmen auf Sanktionen reagieren ist sehr unterschiedlich
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (24:10) Arbeitschancen von geflohenen Ukrainern in der EU
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:40) Wie geht man mit betroffenen Arbeitskollegen um?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (27:51) Was kann jeder von uns tun um zu helfen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (35:00) Side-Projekt: Wie kamen Open Source Projekte zu ihrem Namen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (36:30) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/10-das-karriere-booster-meeting-11s.md
+++ b/src/pages/podcast/episode/10-das-karriere-booster-meeting-11s.md
@@ -44,68 +44,74 @@ title: '#10 Das Karriere Booster Meeting 1:1s'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    1on1s - Zeitverschwendung oder eins der wertvollsten Meetings deiner Karriere?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Andy und Wolfgang sprechen über das meist unterschätzte Meeting deiner beruflichen Laufbahn: 1-on-1s: Purer Müll, Zeitverschwendung und reines Manager-Getue? Oder die beste zeitliche Investition? Wir klären, was 1:1s sind, geben Tipps zum Aufbau einer vertrauensvolle Atmosphäre, geben dir konkrete Fragen an die Hand, die du als Individual Contributor oder Engineering Manager stellen kannst und klären, was du tun kannst, wenn du bisher noch keine regulären Meetings mit deiner Vorgesetzten hast.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum Wolfgang alle 1on1s mit Andy abgebrochen hat.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     101 Fragen für ein 1on1:
-    <a class="underline hover:no-underline" href="https://jasonevanish.com/2014/05/29/101-questions-to-ask-in-1-on-1s/" rel="nofollow">
+    <a href="https://jasonevanish.com/2014/05/29/101-questions-to-ask-in-1-on-1s/" rel="nofollow">
      https://jasonevanish.com/2014/05/29/101-questions-to-ask-in-1-on-1s/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     5 Fragen, die ein Manager jedem seiner Direct Reports stellen sollte:
-    <a class="underline hover:no-underline" href="https://hbr.org/2022/01/5-questions-every-manager-needs-to-ask-their-direct-reports" rel="nofollow">
+    <a href="https://hbr.org/2022/01/5-questions-every-manager-needs-to-ask-their-direct-reports" rel="nofollow">
      https://hbr.org/2022/01/5-questions-every-manager-needs-to-ask-their-direct-reports
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     1on1 for Beginners:
-    <a class="underline hover:no-underline" href="https://www.tombartel.me/blog/one-on-ones-for-beginners/" rel="nofollow">
+    <a href="https://www.tombartel.me/blog/one-on-ones-for-beginners/" rel="nofollow">
      https://www.tombartel.me/blog/one-on-ones-for-beginners/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     1on1: Beyond Status Updates
-    <a class="underline hover:no-underline" href="https://www.tombartel.me/blog/one-on-ones-beyond-status-update/" rel="nofollow">
+    <a href="https://www.tombartel.me/blog/one-on-ones-beyond-status-update/" rel="nofollow">
      https://www.tombartel.me/blog/one-on-ones-beyond-status-update/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Taking notes during 1on1s:
-    <a class="underline hover:no-underline" href="https://www.tombartel.me/blog/taking-notes-during-1-on-1s/" rel="nofollow">
+    <a href="https://www.tombartel.me/blog/taking-notes-during-1-on-1s/" rel="nofollow">
      https://www.tombartel.me/blog/taking-notes-during-1-on-1s/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     How to prepare a 1on1 in 5 minutes:
-    <a class="underline hover:no-underline" href="https://www.tombartel.me/blog/how-to-prepare-one-on-one-five-minutes/" rel="nofollow">
+    <a href="https://www.tombartel.me/blog/how-to-prepare-one-on-one-five-minutes/" rel="nofollow">
      https://www.tombartel.me/blog/how-to-prepare-one-on-one-five-minutes/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Ein Intro zu 1on1s bei Spotify
-    <a class="underline hover:no-underline" href="https://engineering.atspotify.com/2015/12/a-101-on-11s/" rel="nofollow">
+    <a href="https://engineering.atspotify.com/2015/12/a-101-on-11s/" rel="nofollow">
      https://engineering.atspotify.com/2015/12/a-101-on-11s/
     </a>
    </li>
@@ -113,91 +119,100 @@ title: '#10 Das Karriere Booster Meeting 1:1s'
   <h4>
    Tooling
   </h4>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Lighthouse:
-    <a class="underline hover:no-underline" href="https://getlighthouse.com/" rel="nofollow">
+    <a href="https://getlighthouse.com/" rel="nofollow">
      https://getlighthouse.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     OfficeVibe:
-    <a class="underline hover:no-underline" href="https://officevibe.com/one-on-one-software" rel="nofollow">
+    <a href="https://officevibe.com/one-on-one-software" rel="nofollow">
      https://officevibe.com/one-on-one-software
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:30) Warum eine Episode über 1on1s
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:40) Begriffsdefinition "1on1" und ist das ein Jour fixe?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:24) Mythos Zeitverschwendung und unnützes Gespräch
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:23) Sichere und vertrauensvolle Atmosphäre im 1on1
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:28) Tipps um eine sichere Atmosphäre und Vertrauen zu schaffen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:22) Wer sollte ein 1on1 machen? Und was sind Skip-Level Meetings?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (15:53) Sinnvolle 1on1 Intervalle
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (19:35) Was sollte man in 1on1s besprechen? Welche Fragen kann ich als Individual Contributer stellen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (28:52) Wie sollte ein Engineering Manager sein 1on1 vorbereiten und angehen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (39:12) Tooling, die 1on1s supporten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (41:15) Perspektivenwechsel: Fragt eure Managerin
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (42:57) Wie man am besten mit 1on1s beginnt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (44:12) Feedback und Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/11-die-suche-nach-dem-it-traumjob.md
+++ b/src/pages/podcast/episode/11-die-suche-nach-dem-it-traumjob.md
@@ -60,191 +60,206 @@ title: '#11 Die Suche nach dem IT Traumjob'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Den richtigen Arbeitgeber und die richtige Firma finden: Eine Mammut-Aufgabe.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    In dieser Episode sprechen Wolfgang und Andy ein wenig darüber wie man neue, potentielle, Arbeitgeber findet, welche Fragen man sich selbst stellen kann um herauszufinden, was einem wichtig ist, geben Tipps um mit Recruitern zusammen zu arbeiten, Fragen uns ob ein hohes Gehalt wirklich alles ist, ob Startups, ScaleUps oder Konzerne besser sind und warum Agrar-Tech und Mähdrescher der heiße Scheiß sind.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Als Start in dieses Thema gibt es ein Re-Cap von einer User-Umfrage auf Reddit zum Thema 1on1s und die Beantwortung der Frage, wie man gutes (People) Leadership in neuen Firmen erkennt.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Was Andys Kegeltour mit seiner Jobsuche zu tun hat und was ein Mottek ist.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Reddit-Umfrage "Wer von euch hat in seinem IT Job regelmäßig 1on1s (mit Vorgesetzten)?"
-    <a class="underline hover:no-underline" href="https://www.reddit.com/r/de_EDV/comments/tg5y0y/wer_von_euch_hat_in_seinem_it_job_regelm%C3%A4%C3%9Fig/" rel="nofollow">
+    <a href="https://www.reddit.com/r/de_EDV/comments/tg5y0y/wer_von_euch_hat_in_seinem_it_job_regelm%C3%A4%C3%9Fig/" rel="nofollow">
      https://www.reddit.com/r/de_EDV/comments/tg5y0y/wer_von_euch_hat_in_seinem_it_job_regelm%C3%A4%C3%9Fig/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Zend
-    <a class="underline hover:no-underline" href="https://www.zend.com/" rel="nofollow">
+    <a href="https://www.zend.com/" rel="nofollow">
      https://www.zend.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Claas
-    <a class="underline hover:no-underline" href="https://www.claas.de/" rel="nofollow">
+    <a href="https://www.claas.de/" rel="nofollow">
      https://www.claas.de/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     John Deere Just Swindled Farmers out of Their Right to Repair
-    <a class="underline hover:no-underline" href="https://www.wired.com/story/john-deere-farmers-right-to-repair/" rel="nofollow">
+    <a href="https://www.wired.com/story/john-deere-farmers-right-to-repair/" rel="nofollow">
      https://www.wired.com/story/john-deere-farmers-right-to-repair/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Mika Timing
-    <a class="underline hover:no-underline" href="https://www.mikatiming.de/" rel="nofollow">
+    <a href="https://www.mikatiming.de/" rel="nofollow">
      https://www.mikatiming.de/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     TechCrunch
-    <a class="underline hover:no-underline" href="https://techcrunch.com/" rel="nofollow">
+    <a href="https://techcrunch.com/" rel="nofollow">
      https://techcrunch.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     CrunchBase
-    <a class="underline hover:no-underline" href="https://www.crunchbase.com/" rel="nofollow">
+    <a href="https://www.crunchbase.com/" rel="nofollow">
      https://www.crunchbase.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Kafka
-    <a class="underline hover:no-underline" href="https://kafka.apache.org/" rel="nofollow">
+    <a href="https://kafka.apache.org/" rel="nofollow">
      https://kafka.apache.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Deloitte Digital:
-    <a class="underline hover:no-underline" href="https://www2.deloitte.com/de/de/pages/technology/topics/deloitte-digital.html" rel="nofollow">
+    <a href="https://www2.deloitte.com/de/de/pages/technology/topics/deloitte-digital.html" rel="nofollow">
      https://www2.deloitte.com/de/de/pages/technology/topics/deloitte-digital.html
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Confluent:
-    <a class="underline hover:no-underline" href="https://www.confluent.io/" rel="nofollow">
+    <a href="https://www.confluent.io/" rel="nofollow">
      https://www.confluent.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Y Combinator
-    <a class="underline hover:no-underline" href="https://www.ycombinator.com/" rel="nofollow">
+    <a href="https://www.ycombinator.com/" rel="nofollow">
      https://www.ycombinator.com/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:02) Reddit-Umfrage zum Thema 1 on 1 / Episode 10
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (03:02) "Man braucht keine 1 on 1s, wir können immer drüber sprechen"
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:58) Wie wichtig sind 1 on 1s für dich bei deinem neuen Arbeitgeber?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:16) Wie findest du heraus, ob der Lead Erfahrung hat?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (15:05) Ist ein 1on1 ein Weiterentwicklungs-Benefit einer Firma oder Standard, den man annehmen sollte?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (16:49) Welche Weiterentwicklungsmöglichkeiten sind wichtig für die Wahl einer neuen Firma? Was ist einfach zu etablieren?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (18:41) Wie findet man eine neue Firma, bei der man sich bewerben könnte?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:39) Interviews sind auch glückssache
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (24:13) Den Interviewprozess nutzen um zu erfahren, wie andere die Probleme lösen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:50) Firmen finden durch Liebe zum Produkt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (31:56) Firmen finden ohne Liebe zum Produkt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (37:12) Ist ein Startup etwas für mich?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (39:30) Sucht nicht selbst, sondern lasst euch finden (zB über LinkedIn)
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (41:25) Tipps um mit Recruitern zu arbeiten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (45:22) Macht euch Gedanken, was Ihr vom neuen Arbeitgeber erwartet
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (47:51) Gehalt, Geld und wie viel wollt und braucht Ihr?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (51:19) Andys Haupt-Kriterien für eine neue Firma
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (53:50) Wie viele Interviews waren notwendig, um die richtige Firma zu finden?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (55:40) Interviews und Coding Challenges als Side Projetc
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (56:12) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/12-make-oder-buy.md
+++ b/src/pages/podcast/episode/12-make-oder-buy.md
@@ -53,173 +53,185 @@ title: '#12 Make oder Buy'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Make oder Buy: Alles einkaufen oder doch lieber selber machen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Eine Frage die jeder von uns kennt: Sind meine Anforderungen so speziell, dass es kein Produkt auf dem Markt gibt, die diese abdeckt? Kann ich das nicht ggf. sogar besser, wenn ich das selbst mache?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    In dieser Episode versuchen wir das Thema mal etwas zu durchleuchten: Wann sollte man Services einkaufen? Wann doch lieber selbst umsetzen? Wie geht man mit interner Politik und Gegenwehr um? Was kostet das Selbermachen eigentlich und was bedeuten Begriffe wie Total Cost of Ownership, Opportunitätskosten und Shadow-IT eigentlich? Ist Open Source ein Zwischenweg und wie sieht die ganze Security-Mäßig aus?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Ob wir ein Karrierepodcast sind, was man in 1. Semester BWL lernt, welche Sicherheitsanforderungen eine Webagentur aus Wanne-Eickel hat und warum Wolfgang Google mehr vertraut als sich selber.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     HackerNews Comment als Dropbox gelauncht wurde:
-    <a class="underline hover:no-underline" href="https://news.ycombinator.com/item?id=9224" rel="nofollow">
+    <a href="https://news.ycombinator.com/item?id=9224" rel="nofollow">
      https://news.ycombinator.com/item?id=9224
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Okta says hundreds of companies impacted by security breach:
-    <a class="underline hover:no-underline" href="https://techcrunch.com/2022/03/23/okta-breach-sykes-sitel/" rel="nofollow">
+    <a href="https://techcrunch.com/2022/03/23/okta-breach-sykes-sitel/" rel="nofollow">
      https://techcrunch.com/2022/03/23/okta-breach-sykes-sitel/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Looker:
-    <a class="underline hover:no-underline" href="https://www.looker.com/" rel="nofollow">
+    <a href="https://www.looker.com/" rel="nofollow">
      https://www.looker.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Nextcloud:
-    <a class="underline hover:no-underline" href="https://nextcloud.com/" rel="nofollow">
+    <a href="https://nextcloud.com/" rel="nofollow">
      https://nextcloud.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Nextcloud-Angebot bei Hetzner:
-    <a class="underline hover:no-underline" href="https://www.hetzner.com/de/storage/storage-share" rel="nofollow">
+    <a href="https://www.hetzner.com/de/storage/storage-share" rel="nofollow">
      https://www.hetzner.com/de/storage/storage-share
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Render:
-    <a class="underline hover:no-underline" href="https://render.com/" rel="nofollow">
+    <a href="https://render.com/" rel="nofollow">
      https://render.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Vercel:
-    <a class="underline hover:no-underline" href="https://vercel.com/" rel="nofollow">
+    <a href="https://vercel.com/" rel="nofollow">
      https://vercel.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Netlify:
-    <a class="underline hover:no-underline" href="https://www.netlify.com/" rel="nofollow">
+    <a href="https://www.netlify.com/" rel="nofollow">
      https://www.netlify.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     F-Online, die Führerschein-Plattform:
-    <a class="underline hover:no-underline" href="https://www.f-online.at/" rel="nofollow">
+    <a href="https://www.f-online.at/" rel="nofollow">
      https://www.f-online.at/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:33) Sollen wir die Software für unser A/B-Testing kaufen oder selber bauen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (05:23) Reisekosten-Abrechnungen: Wie kann es gehen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:53) Make or buy
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:27) Wolfgangs Stand bei Make or buy im privaten Leben
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (14:45) Wolfgangs Entscheidungskriterien für make or buy
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (15:42) Was ist die eigene Zeit wirklich Wert?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (17:57) Klassische Beispiele für den “make or buy”-Fall in Firmen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (23:42) Was kostet ein Software-Engineer, etwas selbst zu machen (Total Cost of Ownership)
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (28:55) Abgrenzung von make or buy
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (30:14) Opportunitätskosten: Produktivität und User Experience
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (33:40) Welche Bereiche gibt es, wo es Sinn macht, die Produkte nicht einzukaufen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (37:07) Risiken beim Einkaufen von Produkten: Shadow-IT und Workflows
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (41:16) Gegenwehr, fadenscheinige Gründe und interne Politik bei make or buy
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (48:02) Sicherheitsbedenken bei der Benutzung von externen Services
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (50:48) Eigene Erfahrung: Mehr make oder mehr buy?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (56:07) Wann sollte man Software kaufen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (56:39) Wann sollte man die Software selbst bauen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (57:44) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/13-produktivität.md
+++ b/src/pages/podcast/episode/13-produktivität.md
@@ -50,220 +50,238 @@ title: "#13 Produktivit\xE4t"
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Zeit- und Produktivitätsmanagement: Buzzword-Bingo oder bringt das wirklich was?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    So blöd wie das Thema auch klingen mag, es hat Vorteile. Nicht nur im beruflichen Umfeld, sondern auch im privaten. Wolfgang und Andy sprechen über Ihre Art und Weise, Aufgaben zu organisieren, welche Methoden Sie verwenden, welche was bringen und welche Blödsinn sind, wo die Probleme liegen, ob man Talent dafür bracht, wie man sich selbst mit spannenden Aufgaben austricksen kann und wie man damit seinen Vorgesetzten Erziehen kann.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum Wolfgang endlich seine Zahnbürste wechselt, was Volkswagen mit Getting Things Done zu tun hat und wieso Andy ab und zu knatsch mit seiner Frau hat.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Episode 10 zu 1on1s:
-    <a class="underline hover:no-underline" href="https://engineeringkiosk.dev/episodes/10" rel="nofollow">
+    <a href="https://engineeringkiosk.dev/episodes/10" rel="nofollow">
      https://engineeringkiosk.dev/episodes/10
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Remember The Milk:
-    <a class="underline hover:no-underline" href="https://www.rememberthemilk.com/" rel="nofollow">
+    <a href="https://www.rememberthemilk.com/" rel="nofollow">
      https://www.rememberthemilk.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Asana:
-    <a class="underline hover:no-underline" href="https://asana.com/" rel="nofollow">
+    <a href="https://asana.com/" rel="nofollow">
      https://asana.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Things:
-    <a class="underline hover:no-underline" href="https://culturedcode.com/things/" rel="nofollow">
+    <a href="https://culturedcode.com/things/" rel="nofollow">
      https://culturedcode.com/things/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Evernote:
-    <a class="underline hover:no-underline" href="https://evernote.com/" rel="nofollow">
+    <a href="https://evernote.com/" rel="nofollow">
      https://evernote.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Notable:
-    <a class="underline hover:no-underline" href="https://notable.app/" rel="nofollow">
+    <a href="https://notable.app/" rel="nofollow">
      https://notable.app/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     emacs org mode Getting Things Done:
-    <a class="underline hover:no-underline" href="https://orgmode.org/worg/org-gtd-etc.html" rel="nofollow">
+    <a href="https://orgmode.org/worg/org-gtd-etc.html" rel="nofollow">
      https://orgmode.org/worg/org-gtd-etc.html
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Wunderlist:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Wunderlist" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/Wunderlist" rel="nofollow">
      https://de.wikipedia.org/wiki/Wunderlist
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Microsoft TODO App:
-    <a class="underline hover:no-underline" href="https://todo.microsoft.com/tasks/de-de" rel="nofollow">
+    <a href="https://todo.microsoft.com/tasks/de-de" rel="nofollow">
      https://todo.microsoft.com/tasks/de-de
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Wolfgang Gassler - How I Trick My Well Developed Procrastination Skills:
-    <a class="underline hover:no-underline" href="https://wolfgang.gassler.org/trick-my-procrastination-skills/" rel="nofollow">
+    <a href="https://wolfgang.gassler.org/trick-my-procrastination-skills/" rel="nofollow">
      https://wolfgang.gassler.org/trick-my-procrastination-skills/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Paul Graham - Makers Schedule, Managers Schedule:
-    <a class="underline hover:no-underline" href="http://www.paulgraham.com/makersschedule.html" rel="nofollow">
+    <a href="http://www.paulgraham.com/makersschedule.html" rel="nofollow">
      http://www.paulgraham.com/makersschedule.html
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Getting Things Done (YouTube-Video):
-    <a class="underline hover:no-underline" href="https://www.youtube.com/watch?v=gCswMsONkwY" rel="nofollow">
+    <a href="https://www.youtube.com/watch?v=gCswMsONkwY" rel="nofollow">
      https://www.youtube.com/watch?v=gCswMsONkwY
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Eisenhower Prinzip:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Eisenhower-Prinzip" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/Eisenhower-Prinzip" rel="nofollow">
      https://de.wikipedia.org/wiki/Eisenhower-Prinzip
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Inbox Zero:
-    <a class="underline hover:no-underline" href="https://blog.hubspot.de/sales/inbox-zero" rel="nofollow">
+    <a href="https://blog.hubspot.de/sales/inbox-zero" rel="nofollow">
      https://blog.hubspot.de/sales/inbox-zero
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     StudiVZ löscht alle Bugs
-    <a class="underline hover:no-underline" href="https://www.thewebhatesme.com/allgemein/bugfree-the-vz-way/" rel="nofollow">
+    <a href="https://www.thewebhatesme.com/allgemein/bugfree-the-vz-way/" rel="nofollow">
      https://www.thewebhatesme.com/allgemein/bugfree-the-vz-way/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     StudiVZ wird abgeschaltet:
-    <a class="underline hover:no-underline" href="https://taz.de/StudiVZ-wird-abgeschaltet/!5841671/" rel="nofollow">
+    <a href="https://taz.de/StudiVZ-wird-abgeschaltet/!5841671/" rel="nofollow">
      https://taz.de/StudiVZ-wird-abgeschaltet/!5841671/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="bucher">
+  <p>
+   <br/>
+  </p>
+  <h3 id="bucher">
    Bücher
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Getting Things Done: The Art of Stress-Free Productivity von David Allen
    </li>
-   <li class="mb-3">
+   <li>
     Atomic Habits: An Easy &amp; Proven Way to Build Good Habits &amp; Break Bad Ones von James Clear
    </li>
-   <li class="mb-3">
+   <li>
     Checklist Manifesto: How to Get Things Right von Atul Gawande
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Warum Zeit- und Produktivitätsmanagement relevant ist
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (04:44) Zeit-Management als Thema in 1on1s
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (06:08) Getting Things Done (GTD) von David Allen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (12:31) Kritik zu Getting Things Done (GTD)
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (17:02) Muss man jede Regel von Gettings Things Done (GTD) befolgen um es erfolgreich einzusetzen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (18:38) Nutzung von Getting Things Done (GTD) im privaten und im beruflichen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:03) Erinnerungen als Engineering Manager um soziale Kontakte zu pflegen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (23:03) Wie man seine Ehefrau mit Getting Things Done auf die Palme bringen kann
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (25:00) Inbox Zero
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (30:35) Kalender
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (35:24) Eisenhower-Matrix
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (38:46) Herausforderung: Aufgaben aktiv nicht zu tun
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (42:21) Sich selbst mit spannenden Tasks selbst austricksen aka "Shape and Sell"
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (45:21) Das schwierige, mit einer neuen Methode zu starten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (47:33) Welche Tools gibt es? Oder ist Stift und Zettel das Mittel der Wahl?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (52:59) Inspiration durch Blog-Artikel und Bücher
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (55:37) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/14-async-und-await-asynchrones-arbeiten-im-alltag.md
+++ b/src/pages/podcast/episode/14-async-und-await-asynchrones-arbeiten-im-alltag.md
@@ -52,148 +52,160 @@ title: '#14 async und await: asynchrones Arbeiten im Alltag'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Remote-Work, asynchrone und parallele Arbeit und die eigene Work-Life-Balance.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Durch Corona haben wir alle einen Geschmack von der Remote-Arbeit und Home Office bekommen. Einige hassen es, andere lieben es und haben sogar dem Büro für immer den Rücken gekehrt. Aber worauf kommt es denn wirklich an?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Wolfgang und Andy gehen dieser Frage mal auf den Grund: async und await, Event-Loop, Fokus-Zeiten, Eule und Lerche als Menschentypen, Vertrauen im Team, messbare Ergebnisse, Pro-Aktivität und Schreib-Skills. Was das alles miteinander zu tun hat, hört ihr in dieser Episode.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum man in Amsterdam anders meditiert als anderswo, wieso Andys Liebe zu Redis einen Knick bekommen hat und ob Wolfgang wirklich Holländer ist.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Pieter Levels
-    <a class="underline hover:no-underline" href="https://levels.io/async/" rel="nofollow">
+    <a href="https://levels.io/async/" rel="nofollow">
      https://levels.io/async/
     </a>
    </li>
-   <li class="mb-3">
-    <a class="underline hover:no-underline" href="http://nightowlsbook.com/" rel="nofollow">
+   <li>
+    <a href="http://nightowlsbook.com/" rel="nofollow">
      http://nightowlsbook.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Slack:
-    <a class="underline hover:no-underline" href="https://slack.com/" rel="nofollow">
+    <a href="https://slack.com/" rel="nofollow">
      https://slack.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Design Documents at Google:
-    <a class="underline hover:no-underline" href="https://www.industrialempathy.com/posts/design-docs-at-google/" rel="nofollow">
+    <a href="https://www.industrialempathy.com/posts/design-docs-at-google/" rel="nofollow">
      https://www.industrialempathy.com/posts/design-docs-at-google/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Mantis BugTracking:
-    <a class="underline hover:no-underline" href="https://www.mantisbt.org/" rel="nofollow">
+    <a href="https://www.mantisbt.org/" rel="nofollow">
      https://www.mantisbt.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Redmine:
-    <a class="underline hover:no-underline" href="https://www.redmine.org/" rel="nofollow">
+    <a href="https://www.redmine.org/" rel="nofollow">
      https://www.redmine.org/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00) Intro und Rückmeldung zur Episode #13 über Produktivität
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:22) Async + Asynchronität (async, await, event loop)
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (02:00) Vorteil von asynchroner Verarbeitung
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (04:13) Asynchronität vs. Parallelisierung
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (07:08) NodeJS, Callback-Hölle und async/await in Ruby
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (08:27) Warum verwenden wir nicht die asynchrone Herangehensweise um unsere eigene Zeit besser auszunutzen? - Asynchrones Arbeiten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (11:23) Asynchrones Arbeiten, Schlafrhythmus (Eule vs. Lerche) und lange Fokus-Zeiten
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (14:48) Was verstehen wir unser asynchroner Arbeit?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (18:34) Wie kommt man denn zu dem asynchronen Arbeiten (zB als kleine Firma)? (Vertrauen, Pro-Aktivität, Über-Kommunikation)
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (21:29) … was noch? (Kollaboratives Tooling, Energie für Vorschläge und Objektivität, Diagramme, Transparenz)
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (29:12) Die Funktion und Wahrnehmung von Slack in der asynchronen Arbeitswelt
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (34:05) Die Schriftform als Skill und warum dies trainiert werden sollte
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (35:22) Anwendungen von deinen Schreib-Skills im Ticket-System
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (38:50) Technical Writing, Dokumentation und Meeting Protokolle
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (39:26) Design Dokumente als Basis für die asynchrone Arbeit
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (53:32) Tiefere Gedanken während des schreibens
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (54:05) Wrap Up zum Thema asynchrones Arbeiten und Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/15-source-code-kommentare-git-commits-messages-merge-commits-und-branch-visualisierungs-kunst.md
+++ b/src/pages/podcast/episode/15-source-code-kommentare-git-commits-messages-merge-commits-und-branch-visualisierungs-kunst.md
@@ -71,197 +71,212 @@ title: '#15  Source Code Kommentare, Git Commits Messages, Merge Commits und Bra
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Kommentare im Quellcode und Git Commit Messages - Liest die überhaupt wer?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Ein Streit, der so alt ist wie die Software Entwicklung selbst: Code ist Selbsterklärend und braucht keine Kommentare. Oder doch? Und die Git Historie ist auch eigentlich sinnlos. Warum sollte da jemand zurück gehen und sich die Commit Messages durchlesen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Diese Fragen und Themen wie Semantic Versioning, Idiomatische Programmier-Patterns, Merge Commits, Story-Tellung und was Fynn Kliemanns Kunst mit der Git Branch-Visualisierung zu tun hat, klären Wolfgang und Andy in dieser Episode vom Engineering Kiosk.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Warum Andy einen neuen Podcast-Partner sucht und Wolfgang lieber seinen Code angreift, anstatt Ihn zu entwickeln.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Best practices for writing code comments:
-    <a class="underline hover:no-underline" href="https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/" rel="nofollow">
+    <a href="https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/" rel="nofollow">
      https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     SymfonyLive Cologne 2016 - Jan van Thoor - Open Heart Surgery In Production:
-    <a class="underline hover:no-underline" href="https://www.youtube.com/watch?v=vBG5pUn1Olg" rel="nofollow">
+    <a href="https://www.youtube.com/watch?v=vBG5pUn1Olg" rel="nofollow">
      https://www.youtube.com/watch?v=vBG5pUn1Olg
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     What is the best comment in source code you have ever encountered?:
-    <a class="underline hover:no-underline" href="https://stackoverflow.com/questions/184618/what-is-the-best-comment-in-source-code-you-have-ever-encountered" rel="nofollow">
+    <a href="https://stackoverflow.com/questions/184618/what-is-the-best-comment-in-source-code-you-have-ever-encountered" rel="nofollow">
      https://stackoverflow.com/questions/184618/what-is-the-best-comment-in-source-code-you-have-ever-encountered
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Melanie Patrick: Git - How to unfuck
-    <a class="underline hover:no-underline" href="https://www.youtube.com/watch?v=LP4F2rmi4r4" rel="nofollow">
+    <a href="https://www.youtube.com/watch?v=LP4F2rmi4r4" rel="nofollow">
      https://www.youtube.com/watch?v=LP4F2rmi4r4
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Automatische Changelog/Release PRs:
-    <a class="underline hover:no-underline" href="https://github.com/googleapis/release-please" rel="nofollow">
+    <a href="https://github.com/googleapis/release-please" rel="nofollow">
      https://github.com/googleapis/release-please
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Semantic Versioning:
-    <a class="underline hover:no-underline" href="https://semver.org/" rel="nofollow">
+    <a href="https://semver.org/" rel="nofollow">
      https://semver.org/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Software Repository Mining:
-    <a class="underline hover:no-underline" href="https://en.wikipedia.org/wiki/Mining_software_repositories" rel="nofollow">
+    <a href="https://en.wikipedia.org/wiki/Mining_software_repositories" rel="nofollow">
      https://en.wikipedia.org/wiki/Mining_software_repositories
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald - The story of my bachelor thesis about Software Repository Mining:
-    <a class="underline hover:no-underline" href="https://andygrunwald.com/blog/the-story-of-my-bachelor-thesis-about-software-repository-mining/" rel="nofollow">
+    <a href="https://andygrunwald.com/blog/the-story-of-my-bachelor-thesis-about-software-repository-mining/" rel="nofollow">
      https://andygrunwald.com/blog/the-story-of-my-bachelor-thesis-about-software-repository-mining/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Linux Kernel Git Commit Messages Beispiel:
-    <a class="underline hover:no-underline" href="https://github.com/torvalds/linux/commit/3ae87d2f25c0e998da2721ce332e2b80d3d53c39" rel="nofollow">
+    <a href="https://github.com/torvalds/linux/commit/3ae87d2f25c0e998da2721ce332e2b80d3d53c39" rel="nofollow">
      https://github.com/torvalds/linux/commit/3ae87d2f25c0e998da2721ce332e2b80d3d53c39
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:01:21) Home Office: Job und Privat stark trennen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:02:31) Warum macht man Sport und wie steht Wolfgang zur bayerischen Ess- und Feierkultur
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:03:43) Karriere oder Software-Engineering Podcast und Hardcore-Tech-Thema
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:04:38) Wie viel Kommentare hat die letzte Datei, die du in der IDE offen hattest?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:01:16) Wie stehst du allgemein zu Kommentaren?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:01:05) Was sind sinnvolle Kommentare und ist Code wirklich selbsterklärend?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:13:55) Komplexen code refactoren oder lieber gut kommentieren?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:17:40) Kommentare für kopierten Stack Overflow Code
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:19:48) Kommentare für die Business-Domäne
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:20:11) Algorithmen und Variablen mit einem Buchstaben
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:21:46) Können gute Variablen und Funktionsnamen Kommentare ersetzen?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:23:43) Wird der Code fürs Lesen oder Schreiben optimiert?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:25:43) Bit-Shifting versteht doch keiner
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:28:29) Wie komplex eigentlich die Bash-Programmierung sein
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:33:11) TODO-Kommentare im Code oder lieber ein Ticket?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:36:56) Story-Telling im Code und Entwickler-Humor
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:40:02) Kommentare in Deutsch oder Englisch und Domänen-Vokabular
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:42:34) Wie sollten Git Commit Messages aussehen? Und warum Git Commit Messages E-Mail sein können
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:45:39) Isolierte Git Commits für bessere Git Commit Messages
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:46:44) Merge Commits
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:49:59) Strukturierte Git Commit Messages und Nutzung von Prefixes wie bugfix und feature in Git Commit Messages
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:52:13) Was ist Semantic Versioning (SemVer)?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:56:38) Der Linux Kernel als Vorbild für gute Commit Messages
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:57:55) Wolfgangs Meinung zu Merge-Commits
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:59:38) Branch-Visualisierung in Git
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:01:30) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/16-code-reviews-nützlich-oder-bremsen-nur-ein-gutes-team.md
+++ b/src/pages/podcast/episode/16-code-reviews-nützlich-oder-bremsen-nur-ein-gutes-team.md
@@ -73,188 +73,286 @@ title: "#16 Code Reviews: N\xFCtzlich oder bremsen nur ein gutes Team?"
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Code Reviews: Jeder will schnelles Feedback, doch niemand hat Zeit dafür - Eine Hassliebe.
+<p>
+   <span>
+    Code Reviews: Jeder will schnelles Feedback, doch niemand hat Zeit dafür - Eine Hassliebe.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Eine Komponente im Alltag jedes Software Engineers. Egal ob Junior, Senior oder Staff-Engineer. Jeder erstellt Code Reviews und kommentiert die Arbeit von den Kollegen. Doch wie sehen gute Code Reviews aus? Was gehört hinein, was bleibt besser draußen? Wie viel Reviewer machen Sinn? Wie geht man mit Nitpicking-Kommentaren und Gatekeepern um? Und allgemein: Zieht dieser zusätzliche Schritt nicht die Performance des Teams runter und ist sowieso Overhead?
+  <p>
+   <span>
+    Eine Komponente im Alltag jedes Software Engineers. Egal ob Junior, Senior oder Staff-Engineer. Jeder erstellt Code Reviews und kommentiert die Arbeit von den Kollegen. Doch wie sehen gute Code Reviews aus? Was gehört hinein, was bleibt besser draußen? Wie viel Reviewer machen Sinn? Wie geht man mit Nitpicking-Kommentaren und Gatekeepern um? Und allgemein: Zieht dieser zusätzliche Schritt nicht die Performance des Teams runter und ist sowieso Overhead?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   All das und noch viel mehr in dieser Episode zum Thema Code Reviews.
+  <p>
+   <span>
+    All das und noch viel mehr in dieser Episode zum Thema Code Reviews.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Bonus: Was Faultiere und Markus Söder mit Code Reviews zu tun haben und warum Blubberwasser den Charakter verdirbt.
+  <p>
+   <span>
+    Bonus: Was Faultiere und Markus Söder mit Code Reviews zu tun haben und warum Blubberwasser den Charakter verdirbt.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Feedback an
+   </span>
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Google Fellows:
-    <a class="underline hover:no-underline" href="https://www.newyorker.com/magazine/2018/12/10/the-friendship-that-made-google-huge" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Google Fellows:
+    </span>
+    <a href="https://www.newyorker.com/magazine/2018/12/10/the-friendship-that-made-google-huge" rel="nofollow">
      https://www.newyorker.com/magazine/2018/12/10/the-friendship-that-made-google-huge
     </a>
    </li>
-   <li class="mb-3">
-    Code Owners File:
-    <a class="underline hover:no-underline" href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners" rel="nofollow">
+   <li>
+    <span>
+     Code Owners File:
+    </span>
+    <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners" rel="nofollow">
      https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
     </a>
    </li>
-   <li class="mb-3">
-    Software Repository Mining:
-    <a class="underline hover:no-underline" href="https://en.wikipedia.org/wiki/Mining_software_repositories" rel="nofollow">
+   <li>
+    <span>
+     Software Repository Mining:
+    </span>
+    <a href="https://en.wikipedia.org/wiki/Mining_software_repositories" rel="nofollow">
      https://en.wikipedia.org/wiki/Mining_software_repositories
     </a>
    </li>
-   <li class="mb-3">
-    Round Robin Code Review Assignment:
-    <a class="underline hover:no-underline" href="https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team" rel="nofollow">
+   <li>
+    <span>
+     Round Robin Code Review Assignment:
+    </span>
+    <a href="https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team" rel="nofollow">
      https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team
     </a>
    </li>
-   <li class="mb-3">
-    Inner Source:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Inner_Source" rel="nofollow">
+   <li>
+    <span>
+     Inner Source:
+    </span>
+    <a href="https://de.wikipedia.org/wiki/Inner_Source" rel="nofollow">
      https://de.wikipedia.org/wiki/Inner_Source
     </a>
    </li>
-   <li class="mb-3">
-    Suggesting Changes on GitHub:
-    <a class="underline hover:no-underline" href="http://haacked.com/archive/2019/06/03/suggested-changes/" rel="nofollow">
+   <li>
+    <span>
+     Suggesting Changes on GitHub:
+    </span>
+    <a href="http://haacked.com/archive/2019/06/03/suggested-changes/" rel="nofollow">
      http://haacked.com/archive/2019/06/03/suggested-changes/
     </a>
    </li>
-   <li class="mb-3">
-    Are Pull Requests Holding Back Your Team?:
-    <a class="underline hover:no-underline" href="https://betterprogramming.pub/are-pull-requests-holding-back-your-team-e8aec48986c2" rel="nofollow">
+   <li>
+    <span>
+     Are Pull Requests Holding Back Your Team?:
+    </span>
+    <a href="https://betterprogramming.pub/are-pull-requests-holding-back-your-team-e8aec48986c2" rel="nofollow">
      https://betterprogramming.pub/are-pull-requests-holding-back-your-team-e8aec48986c2
     </a>
    </li>
-   <li class="mb-3">
-    Extrem Programming:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Extreme_Programming" rel="nofollow">
+   <li>
+    <span>
+     Extrem Programming:
+    </span>
+    <a href="https://de.wikipedia.org/wiki/Extreme_Programming" rel="nofollow">
      https://de.wikipedia.org/wiki/Extreme_Programming
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00) Intro
+  <p>
+   <span>
+    (00:00) Intro
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (01:23) Amsterdam, Hipster und Craft-Bier
+  <p>
+   <span>
+    (01:23) Amsterdam, Hipster und Craft-Bier
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (02:04) git rebase, history rewrite, force push und Kollaboration
+  <p>
+   <span>
+    (02:04) git rebase, history rewrite, force push und Kollaboration
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (04:54) Saubere git history und Merge-Commits
+  <p>
+   <span>
+    (04:54) Saubere git history und Merge-Commits
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (05:17) Code Reviews
+  <p>
+   <span>
+    (05:17) Code Reviews
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (02:05) Was ist denn ein Code Review?
+  <p>
+   <span>
+    (02:05) Was ist denn ein Code Review?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (07:02) Muss der Code Reviewer immer mehr Erfahrung haben?
+  <p>
+   <span>
+    (07:02) Muss der Code Reviewer immer mehr Erfahrung haben?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (08:10) Was wir von Juniors im Job und bei Code Reviews lernen können
+  <p>
+   <span>
+    (08:10) Was wir von Juniors im Job und bei Code Reviews lernen können
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (09:37) Was ist denn ein Google Fellow?
+  <p>
+   <span>
+    (09:37) Was ist denn ein Google Fellow?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (10:37) Code Reviews als Mittel fürs Onboarding
+  <p>
+   <span>
+    (10:37) Code Reviews als Mittel fürs Onboarding
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (11:35) Frühes pushen der Arbeit ist wichtig für frühes Feedback
+  <p>
+   <span>
+    (11:35) Frühes pushen der Arbeit ist wichtig für frühes Feedback
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (13:15) Wo sollen die Informationen zu meiner Änderung stehen? Im Pull Request oder in der Git Commit message?
+  <p>
+   <span>
+    (13:15) Wo sollen die Informationen zu meiner Änderung stehen? Im Pull Request oder in der Git Commit message?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (15:04) Wen lade ich zu meinem Code Review ein? Code Owners file und Software Repository Mining
+  <p>
+   <span>
+    (15:04) Wen lade ich zu meinem Code Review ein? Code Owners file und Software Repository Mining
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (17:34) Worauf soll ich als Code Reviewer acht geben und konzentrieren?
+  <p>
+   <span>
+    (17:34) Worauf soll ich als Code Reviewer acht geben und konzentrieren?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (20:09) Pro-Aktivität in Code Reviews mit aktiven Vorschlägen und Fragen stellen
+  <p>
+   <span>
+    (20:09) Pro-Aktivität in Code Reviews mit aktiven Vorschlägen und Fragen stellen
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (23:33) Muss man jedes Feedback aus dem Code Review annehmen? Lass das Ego vor der Tür und Gate-Keeper
+  <p>
+   <span>
+    (23:33) Muss man jedes Feedback aus dem Code Review annehmen? Lass das Ego vor der Tür und Gate-Keeper
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (26:37) Kommunikationskonflikte in Code Reviews: Video Calls vs. geschriebene Kommunikation
+  <p>
+   <span>
+    (26:37) Kommunikationskonflikte in Code Reviews: Video Calls vs. geschriebene Kommunikation
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (28:14) Nitpicking, Code-Formatting, Styleguides, Linter und Automatisierung
+  <p>
+   <span>
+    (28:14) Nitpicking, Code-Formatting, Styleguides, Linter und Automatisierung
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (32:11) Mindern Pull Requests und Code Reviews die Performance von Teams?
+  <p>
+   <span>
+    (32:11) Mindern Pull Requests und Code Reviews die Performance von Teams?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (36:56) Schnelligkeit bei Facebook und Booking: Schnelles Mergen und Code Reviews danach
+  <p>
+   <span>
+    (36:56) Schnelligkeit bei Facebook und Booking: Schnelles Mergen und Code Reviews danach
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (39:01) Auslagerung der Verantwortung bei Code Reviews und Blameless Kultur innerhalb der Firma
+  <p>
+   <span>
+    (39:01) Auslagerung der Verantwortung bei Code Reviews und Blameless Kultur innerhalb der Firma
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (42:38) Technische Mittel für sichere Deploys: Feature Flags, Canary Deployments, Dark Launches und Blue-Green-Deployments
+  <p>
+   <span>
+    (42:38) Technische Mittel für sichere Deploys: Feature Flags, Canary Deployments, Dark Launches und Blue-Green-Deployments
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (46:08) Wie schnell sollte ein Code Review vom Team gereviewed werden?
+  <p>
+   <span>
+    (46:08) Wie schnell sollte ein Code Review vom Team gereviewed werden?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (53:00) Code Reviews in der Firma vs. Code Reviews in Open Source und die Motivation
+  <p>
+   <span>
+    (53:00) Code Reviews in der Firma vs. Code Reviews in Open Source und die Motivation
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (54:34) Konsequenzen bei nicht eingehaltenen Service Level Agreements (SLA)
+  <p>
+   <span>
+    (54:34) Konsequenzen bei nicht eingehaltenen Service Level Agreements (SLA)
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (57:28) Outro
+  <p>
+   <span>
+    (57:28) Outro
+   </span>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Wolfgang Gassler (
+    </span>
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
-   <li class="mb-3">
-    Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <li>
+    <span>
+     Andy Grunwald (
+    </span>
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Engineering Kiosk Podcast: Anfragen an
+   </span>
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/17-was-können-wir-beim-incident-management-von-der-feuerwehr-lernen.md
+++ b/src/pages/podcast/episode/17-was-können-wir-beim-incident-management-von-der-feuerwehr-lernen.md
@@ -79,251 +79,266 @@ title: "#17 Was k\xF6nnen wir beim Incident Management von der Feuerwehr lernen?
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Was haben die Methoden der Feuerwehr zur Bekämpfung von Großschadensereignissen mit dem Incident Management von IT-Systemen gemeinsam?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Diese Frage klären wir in der folgenden Episode. Wolfgang, als Mitglied der freiwilligen Feuerwehr, gibt einen Einblick in das Prozedere, wenn die Feuerwehr ausrückt. Andy vergleicht dies mit dem Incident Management von Cloud-Systemen. Wir klären wie man den Schaden eines Incidents misst, was dies mit dem Vertrauen von Kunden zu tun hat, wie ordentliche Prävention aussehen kann und warum es dafür wenig Ruhm gibt, was man unter War- und Peacetime versteht, wie ein moderner “Schreiberling” aussieht, wie dreist Presseleute sein können und was eine kleine Konferenz in Kalifornien damit zu tun hat.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Was Gartenschläuche und Stahl-Hochöfen damit zu tun haben und wieso Kaffee holen doch eine Strategie sein kann.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Datenverlust bei 1.500 Snapshots von Hetzner Cloud:
-    <a class="underline hover:no-underline" href="https://www.golem.de/news/trotz-redundanz-datenverlust-bei-1-500-snapshots-von-hetzner-cloud-2204-164628.html" rel="nofollow">
+    <a href="https://www.golem.de/news/trotz-redundanz-datenverlust-bei-1-500-snapshots-von-hetzner-cloud-2204-164628.html" rel="nofollow">
      https://www.golem.de/news/trotz-redundanz-datenverlust-bei-1-500-snapshots-von-hetzner-cloud-2204-164628.html
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Ceph Storage:
-    <a class="underline hover:no-underline" href="https://ceph.io/" rel="nofollow">
+    <a href="https://ceph.io/" rel="nofollow">
      https://ceph.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Inside the Longest Atlassian Outage of All Time:
-    <a class="underline hover:no-underline" href="https://newsletter.pragmaticengineer.com/p/scoop-atlassian" rel="nofollow">
+    <a href="https://newsletter.pragmaticengineer.com/p/scoop-atlassian" rel="nofollow">
      https://newsletter.pragmaticengineer.com/p/scoop-atlassian
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Atlassian stoppt den Verkauf von On-Premise Lizenzen:
-    <a class="underline hover:no-underline" href="https://www.atlassian.com/migration/assess/journey-to-cloud" rel="nofollow">
+    <a href="https://www.atlassian.com/migration/assess/journey-to-cloud" rel="nofollow">
      https://www.atlassian.com/migration/assess/journey-to-cloud
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     auditd:
-    <a class="underline hover:no-underline" href="https://linux.die.net/man/8/auditd" rel="nofollow">
+    <a href="https://linux.die.net/man/8/auditd" rel="nofollow">
      https://linux.die.net/man/8/auditd
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     rsyslog:
-    <a class="underline hover:no-underline" href="https://www.rsyslog.com/" rel="nofollow">
+    <a href="https://www.rsyslog.com/" rel="nofollow">
      https://www.rsyslog.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Incident.io:
-    <a class="underline hover:no-underline" href="https://incident.io/" rel="nofollow">
+    <a href="https://incident.io/" rel="nofollow">
      https://incident.io/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     5-Why-Methode:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/5-Why-Methode" rel="nofollow">
+    <a href="https://de.wikipedia.org/wiki/5-Why-Methode" rel="nofollow">
      https://de.wikipedia.org/wiki/5-Why-Methode
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Postmortem “Roblox Return to Service 10/28-10/31 2021”:
-    <a class="underline hover:no-underline" href="https://blog.roblox.com/2022/01/roblox-return-to-service-10-28-10-31-2021/" rel="nofollow">
+    <a href="https://blog.roblox.com/2022/01/roblox-return-to-service-10-28-10-31-2021/" rel="nofollow">
      https://blog.roblox.com/2022/01/roblox-return-to-service-10-28-10-31-2021/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Postmortem “The Discovery of Apache ZooKeeper’s Poison Packet”:
-    <a class="underline hover:no-underline" href="https://www.pagerduty.com/blog/the-discovery-of-apache-zookeepers-poison-packet/" rel="nofollow">
+    <a href="https://www.pagerduty.com/blog/the-discovery-of-apache-zookeepers-poison-packet/" rel="nofollow">
      https://www.pagerduty.com/blog/the-discovery-of-apache-zookeepers-poison-packet/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Postmortem “etcd: v3.5 data inconsistency”:
-    <a class="underline hover:no-underline" href="https://github.com/etcd-io/etcd/blob/main/Documentation/postmortems/v3.5-data-inconsistency.md" rel="nofollow">
+    <a href="https://github.com/etcd-io/etcd/blob/main/Documentation/postmortems/v3.5-data-inconsistency.md" rel="nofollow">
      https://github.com/etcd-io/etcd/blob/main/Documentation/postmortems/v3.5-data-inconsistency.md
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Postmortem: “Gocardless: Incident review: API and Dashboard outage on 10 October 2017”:
-    <a class="underline hover:no-underline" href="https://gocardless.com/blog/incident-review-api-and-dashboard-outage-on-10th-october/" rel="nofollow">
+    <a href="https://gocardless.com/blog/incident-review-api-and-dashboard-outage-on-10th-october/" rel="nofollow">
      https://gocardless.com/blog/incident-review-api-and-dashboard-outage-on-10th-october/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Postmortem: “Monzo,Outage, 29. July 2019”:
-    <a class="underline hover:no-underline" href="https://monzo.com/blog/2019/09/08/why-monzo-wasnt-working-on-july-29th" rel="nofollow">
+    <a href="https://monzo.com/blog/2019/09/08/why-monzo-wasnt-working-on-july-29th" rel="nofollow">
      https://monzo.com/blog/2019/09/08/why-monzo-wasnt-working-on-july-29th
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Sammlung von verschiedenen Postmortems:
-    <a class="underline hover:no-underline" href="https://github.com/danluu/post-mortems" rel="nofollow">
+    <a href="https://github.com/danluu/post-mortems" rel="nofollow">
      https://github.com/danluu/post-mortems
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     OpsGenie:
-    <a class="underline hover:no-underline" href="https://www.atlassian.com/de/software/opsgenie" rel="nofollow">
+    <a href="https://www.atlassian.com/de/software/opsgenie" rel="nofollow">
      https://www.atlassian.com/de/software/opsgenie
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     PagerDuty:
-    <a class="underline hover:no-underline" href="https://www.pagerduty.com/" rel="nofollow">
+    <a href="https://www.pagerduty.com/" rel="nofollow">
      https://www.pagerduty.com/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Buch “Incident Management for Operations”:
-    <a class="underline hover:no-underline" href="https://www.amazon.de/Incident-Management-Operations-Rob-Schnepp/dp/1491917628" rel="nofollow">
+    <a href="https://www.amazon.de/Incident-Management-Operations-Rob-Schnepp/dp/1491917628" rel="nofollow">
      https://www.amazon.de/Incident-Management-Operations-Rob-Schnepp/dp/1491917628
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3>
+   <br/>
+  </h3>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:01:21) Wie viel Feuerwehr-Leute gibt es in Deutschland?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:02:58) Was ist Incident Management im DevOps/Infrastruktur-Bereich
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:07:33) Firmen-Interne Incidents können ebenfalls richtig teuer werden
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:09:14) Wie wichtig ist Prävention und Monitoring?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:10:26) Wie agiert ein Unternehmen bei einem IT-Incident? Chaotische Hilfe
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:12:33) Inwieweit kann ein IT-Incident mit einem Großschadensereignis verglichen werden?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:14:14) Was ist ein Großschadensereignis?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:15:57) Wie bekommen denn alle mit, dass ein Incident gerade eintritt? Und welche Strukturen sind notwendig?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:17:43) Wer übernimmt die Rolle des (Incident) Commanders?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:19:21) Was beinhaltet denn die Übernahme eines Incidents?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:21:23) Vergleich von der Übernahme eines Incidents zwischen der Feuerwehr und einem IT-System
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:23:43) Strategie der Feuerwehr bei Incidents und Hierarchien
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:26:14) Ist der Einsatzleiter ein aktiver Teil des Incidents? Und welche Rollen gibt es noch?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:30:09) Kommunikationsstrukturen in IT-Incidents
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:33:01) Der aktuelle Atlassian-Incident
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:34:44) Die Rollen von Logistik und Administration in der Feuerwehr und in der IT
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:37:16) (Essens)-Logistik bei Remote-Incidents
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:40:19) War-Rooms: Anti-Pattern oder Must-Have + Pro-Aktive Kommunikation
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:43:26) War- und Peace-Time
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:44:19) Incident Commander, Rollen und Rollen-Rotation im IT-Bereich
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:45:53) Die Rolle des Protokollführers / Schreiberlings
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:50:46) Post Mortems und Nachbesprechungen: Warum machen die Sinn?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:54:21) Vorbereitungen, Prävention und Training in der Friedenszeit
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:57:51) Lernen aus Incidents und die Post Mortem-Struktur
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:00:09) Employer Branding mit Post Mortems
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:01:45) Happy-Path in Post Mortems
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:02:35) Nachbesprechung bei der Feuerwehr und Post Mortem Conferences
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:06:45) Web-Ops / Fire-Ops-Conference
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:09:40) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <h3>
+   <br/>
+  </h3>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/18-ziele-und-performance-metriken-für-teams-und-mich-selbst.md
+++ b/src/pages/podcast/episode/18-ziele-und-performance-metriken-für-teams-und-mich-selbst.md
@@ -61,161 +61,252 @@ title: "#18 Ziele und Performance-Metriken f\xFCr Teams und mich selbst"
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Ziel-Definitionen und Mitarbeiter-Metriken: Sinnvoll oder totaler Blödsinn?
+<p>
+   <span>
+    Ziel-Definitionen und Mitarbeiter-Metriken: Sinnvoll oder totaler Blödsinn?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Das Thema ist heiß umstritten. Viele lieben Ziele im Job. Andere sind eher auf dem Trichter von “Wer misst, misst Mist.”. In dieser Episode sprechen Wolfgang und Andy über individuelle Ziele, Team-Ziele und über die Frage, ob sich das Team in die richtige Richtung bewegt. Unter anderem mit Fragen wie, ob es immer mathematisch messbare Ziele sein müssen, wie man mit subjektiven Zielen umgeht, ob man Lines of Code messen sollte, was die Velocity aus dem Scrum Framework mit OKRs zu tun haben und noch vieles mehr.
+  <p>
+   <span>
+    Das Thema ist heiß umstritten. Viele lieben Ziele im Job. Andere sind eher auf dem Trichter von “Wer misst, misst Mist.”. In dieser Episode sprechen Wolfgang und Andy über individuelle Ziele, Team-Ziele und über die Frage, ob sich das Team in die richtige Richtung bewegt. Unter anderem mit Fragen wie, ob es immer mathematisch messbare Ziele sein müssen, wie man mit subjektiven Zielen umgeht, ob man Lines of Code messen sollte, was die Velocity aus dem Scrum Framework mit OKRs zu tun haben und noch vieles mehr.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Bonus: Wieso Österreicher Podcasts anschauen können und was das Fortuna Düsseldorf und das Sams mit der ganzen Sache zu tun hat.
+  <p>
+   <span>
+    Bonus: Wieso Österreicher Podcasts anschauen können und was das Fortuna Düsseldorf und das Sams mit der ganzen Sache zu tun hat.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Feedback an
+   </span>
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Reddit-Disukssion:
-    <a class="underline hover:no-underline" href="https://www.reddit.com/r/de_EDV/comments/uhnn4c/wie_werdet_ihr_als_mitarbeiter_und_euer_team/" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Reddit-Disukssion:
+    </span>
+    <a href="https://www.reddit.com/r/de_EDV/comments/uhnn4c/wie_werdet_ihr_als_mitarbeiter_und_euer_team/" rel="nofollow">
      https://www.reddit.com/r/de_EDV/comments/uhnn4c/wie_werdet_ihr_als_mitarbeiter_und_euer_team/
     </a>
    </li>
-   <li class="mb-3">
-    Sentry:
-    <a class="underline hover:no-underline" href="https://sentry.io/" rel="nofollow">
+   <li>
+    <span>
+     Sentry:
+    </span>
+    <a href="https://sentry.io/" rel="nofollow">
      https://sentry.io/
     </a>
    </li>
-   <li class="mb-3">
-    OKR Beispiele für Software Teams:
-    <a class="underline hover:no-underline" href="https://www.koan.co/okr-examples/engineering" rel="nofollow">
+   <li>
+    <span>
+     OKR Beispiele für Software Teams:
+    </span>
+    <a href="https://www.koan.co/okr-examples/engineering" rel="nofollow">
      https://www.koan.co/okr-examples/engineering
     </a>
    </li>
-   <li class="mb-3">
-    OfficeVibe:
-    <a class="underline hover:no-underline" href="https://officevibe.com/" rel="nofollow">
+   <li>
+    <span>
+     OfficeVibe:
+    </span>
+    <a href="https://officevibe.com/" rel="nofollow">
      https://officevibe.com/
     </a>
    </li>
-   <li class="mb-3">
-    DevOps-Kultur: Organisationskultur von Westrum:
-    <a class="underline hover:no-underline" href="https://cloud.google.com/architecture/devops/devops-culture-westrum-organizational-culture" rel="nofollow">
+   <li>
+    <span>
+     DevOps-Kultur: Organisationskultur von Westrum:
+    </span>
+    <a href="https://cloud.google.com/architecture/devops/devops-culture-westrum-organizational-culture" rel="nofollow">
      https://cloud.google.com/architecture/devops/devops-culture-westrum-organizational-culture
     </a>
    </li>
-   <li class="mb-3">
-    CircleCi Engineering Kompetenz-Matrix:
-    <a class="underline hover:no-underline" href="https://docs.google.com/spreadsheets/d/131XZCEb8LoXqy79WWrhCX4sBnGhCM1nAIz4feFZJsEo/edit#gid=0" rel="nofollow">
+   <li>
+    <span>
+     CircleCi Engineering Kompetenz-Matrix:
+    </span>
+    <a href="https://docs.google.com/spreadsheets/d/131XZCEb8LoXqy79WWrhCX4sBnGhCM1nAIz4feFZJsEo/edit#gid=0" rel="nofollow">
      https://docs.google.com/spreadsheets/d/131XZCEb8LoXqy79WWrhCX4sBnGhCM1nAIz4feFZJsEo/edit#gid=0
     </a>
    </li>
-   <li class="mb-3">
-    DORA Metriken:
-    <a class="underline hover:no-underline" href="https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance" rel="nofollow">
+   <li>
+    <span>
+     DORA Metriken:
+    </span>
+    <a href="https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance" rel="nofollow">
      https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <h3>
+   <br/>
+  </h3>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00:00) Intro
+  <p>
+   <span>
+    (00:00:00) Intro
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:01:37) Helft uns mit eurem Netzwerk durch eine Podcast-Empfehlung
+  <p>
+   <span>
+    (00:01:37) Helft uns mit eurem Netzwerk durch eine Podcast-Empfehlung
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:02:02) Wie kam das Thema dieser Podcast-Folge zustande? Team Metriken, Einzel-Metriken und Performance-Metriken von Mitarbeitern
+  <p>
+   <span>
+    (00:02:02) Wie kam das Thema dieser Podcast-Folge zustande? Team Metriken, Einzel-Metriken und Performance-Metriken von Mitarbeitern
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:06:06) Drei Kategorien: Individuelle Ziele, Team-Ziele und "Bewegt sich das Team in die richtige Richtung?"
+  <p>
+   <span>
+    (00:06:06) Drei Kategorien: Individuelle Ziele, Team-Ziele und "Bewegt sich das Team in die richtige Richtung?"
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:06:36) Individuelle Ziele: Warum ist das Thema relevant? Warum sollte man sich über Ziele unterhalten?
+  <p>
+   <span>
+    (00:06:36) Individuelle Ziele: Warum ist das Thema relevant? Warum sollte man sich über Ziele unterhalten?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:13:50) Objective Key Results (OKR) als mögliche Ziele
+  <p>
+   <span>
+    (00:13:50) Objective Key Results (OKR) als mögliche Ziele
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:18:09) Die Kritik von Objective und Key Results als individuelle Ziele
+  <p>
+   <span>
+    (00:18:09) Die Kritik von Objective und Key Results als individuelle Ziele
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:21:19) Transparenz von Zielen im Team und in der Firma
+  <p>
+   <span>
+    (00:21:19) Transparenz von Zielen im Team und in der Firma
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:23:44) Planung und Ziele ist unnütz und Overhead
+  <p>
+   <span>
+    (00:23:44) Planung und Ziele ist unnütz und Overhead
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:25:05) Antipatterns und Ziele die man vermeiden sollte
+  <p>
+   <span>
+    (00:25:05) Antipatterns und Ziele die man vermeiden sollte
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:26:31) Was ist die Velocity innerhalb vom Kontext Scrum? Und wie sollte diese Metrik bewertet werden?
+  <p>
+   <span>
+    (00:26:31) Was ist die Velocity innerhalb vom Kontext Scrum? Und wie sollte diese Metrik bewertet werden?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:31:27) Die Nutzung von Code- und Software Repository Mining-Metriken als Basis zur Zielsetzung
+  <p>
+   <span>
+    (00:31:27) Die Nutzung von Code- und Software Repository Mining-Metriken als Basis zur Zielsetzung
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:37:12) Team-Metrik "Happyness" und wie man es messen kann
+  <p>
+   <span>
+    (00:37:12) Team-Metrik "Happyness" und wie man es messen kann
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:42:22) Das Westrum-Modell, OfficeVibe und Google Forms
+  <p>
+   <span>
+    (00:42:22) Das Westrum-Modell, OfficeVibe und Google Forms
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:45:43) 360* Feedback: Was ist es und die Kritik am System
+  <p>
+   <span>
+    (00:45:43) 360* Feedback: Was ist es und die Kritik am System
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:52:26) Vergleichbarkeit von Software Engineers und Levels
+  <p>
+   <span>
+    (00:52:26) Vergleichbarkeit von Software Engineers und Levels
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:57:45) Jobtitel und individuelle Ziele und höhere Erwartungen
+  <p>
+   <span>
+    (00:57:45) Jobtitel und individuelle Ziele und höhere Erwartungen
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:59:00) "Bewegt sich das Team in die richtige Richtung?", DORA-Metriken und Well-Rounded Software Engineer
+  <p>
+   <span>
+    (00:59:00) "Bewegt sich das Team in die richtige Richtung?", DORA-Metriken und Well-Rounded Software Engineer
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (01:03:30) Zieldefinitionen sind nicht einfach und Kontext ist King
+  <p>
+   <span>
+    (01:03:30) Zieldefinitionen sind nicht einfach und Kontext ist King
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (01:07:46) Outro
+  <p>
+   <span>
+    (01:07:46) Outro
+   </span>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Wolfgang Gassler (
+    </span>
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
-   <li class="mb-3">
-    Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <li>
+    <span>
+     Andy Grunwald (
+    </span>
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Engineering Kiosk Podcast: Anfragen an
+   </span>
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/19-datenbank-deepdive-oder-das-ende-einer-ära-von-redis-bis-clickhouse.md
+++ b/src/pages/podcast/episode/19-datenbank-deepdive-oder-das-ende-einer-ära-von-redis-bis-clickhouse.md
@@ -75,267 +75,399 @@ title: "#19 Datenbank-Deepdive (oder das Ende einer \xC4ra): von Redis bis Click
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Der zweite Datenbank-Deepdive im Engineering Kiosk.
+<p>
+   <span>
+    Der zweite Datenbank-Deepdive im Engineering Kiosk.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Indirekt knüpfen wir an Episode 8 mit dem Thema Datenbanken. Diesmal fangen wir aber ganz vorne an: Mit hierarchischen Datenbanken über Objektorientierte Datenbanken, anschließend zu SQL bis hin zur NoSQL und Spaltenorientierten Datenbank-Ära. Dabei klären wir Fragen was zum Beispiel der Unterschied zwischen Datenbanken und Dateien ist, ob OOP-Datenbank immer noch ein Hype ist, was Indexe sind und wie diese funktionieren, warum die Migration weg von Oracle schwierig sein kann, ob Lucene eine Datenbank ist und noch viel viel mehr.
+  <p>
+   <span>
+    Indirekt knüpfen wir an Episode 8 mit dem Thema Datenbanken. Diesmal fangen wir aber ganz vorne an: Mit hierarchischen Datenbanken über Objektorientierte Datenbanken, anschließend zu SQL bis hin zur NoSQL und Spaltenorientierten Datenbank-Ära. Dabei klären wir Fragen was zum Beispiel der Unterschied zwischen Datenbanken und Dateien ist, ob OOP-Datenbank immer noch ein Hype ist, was Indexe sind und wie diese funktionieren, warum die Migration weg von Oracle schwierig sein kann, ob Lucene eine Datenbank ist und noch viel viel mehr.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Bonus: Was Kürbiskerne mit Datenbanken zu tun haben und warum MySQL ein besseres Adressbuch mit SQL Interface ist.
+  <p>
+   <span>
+    Bonus: Was Kürbiskerne mit Datenbanken zu tun haben und warum MySQL ein besseres Adressbuch mit SQL Interface ist.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Feedback an
+   </span>
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    IBM Mainframes:
-    <a class="underline hover:no-underline" href="https://www.ibm.com/de-de/it-infrastructure/z" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     IBM Mainframes:
+    </span>
+    <a href="https://www.ibm.com/de-de/it-infrastructure/z" rel="nofollow">
      https://www.ibm.com/de-de/it-infrastructure/z
     </a>
    </li>
-   <li class="mb-3">
-    ClickHouse:
-    <a class="underline hover:no-underline" href="https://github.com/ClickHouse/ClickHouse" rel="nofollow">
+   <li>
+    <span>
+     ClickHouse:
+    </span>
+    <a href="https://github.com/ClickHouse/ClickHouse" rel="nofollow">
      https://github.com/ClickHouse/ClickHouse
     </a>
-    /
-    <a class="underline hover:no-underline" href="https://clickhouse.com/" rel="nofollow">
+    <span>
+     /
+    </span>
+    <a href="https://clickhouse.com/" rel="nofollow">
      https://clickhouse.com/
     </a>
    </li>
-   <li class="mb-3">
-    Oracle Cloud Free Tier:
-    <a class="underline hover:no-underline" href="https://www.oracle.com/de/cloud/free/" rel="nofollow">
+   <li>
+    <span>
+     Oracle Cloud Free Tier:
+    </span>
+    <a href="https://www.oracle.com/de/cloud/free/" rel="nofollow">
      https://www.oracle.com/de/cloud/free/
     </a>
    </li>
-   <li class="mb-3">
-    Apache Lucene:
-    <a class="underline hover:no-underline" href="https://lucene.apache.org/" rel="nofollow">
+   <li>
+    <span>
+     Apache Lucene:
+    </span>
+    <a href="https://lucene.apache.org/" rel="nofollow">
      https://lucene.apache.org/
     </a>
    </li>
-   <li class="mb-3">
-    Apache Solr:
-    <a class="underline hover:no-underline" href="https://solr.apache.org/" rel="nofollow">
+   <li>
+    <span>
+     Apache Solr:
+    </span>
+    <a href="https://solr.apache.org/" rel="nofollow">
      https://solr.apache.org/
     </a>
    </li>
-   <li class="mb-3">
-    ElasticSearch:
-    <a class="underline hover:no-underline" href="https://github.com/elastic/elasticsearch" rel="nofollow">
+   <li>
+    <span>
+     ElasticSearch:
+    </span>
+    <a href="https://github.com/elastic/elasticsearch" rel="nofollow">
      https://github.com/elastic/elasticsearch
     </a>
    </li>
-   <li class="mb-3">
-    Liste der Datenbankmanagementsysteme:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Liste_der_Datenbankmanagementsysteme" rel="nofollow">
+   <li>
+    <span>
+     Liste der Datenbankmanagementsysteme:
+    </span>
+    <a href="https://de.wikipedia.org/wiki/Liste_der_Datenbankmanagementsysteme" rel="nofollow">
      https://de.wikipedia.org/wiki/Liste_der_Datenbankmanagementsysteme
     </a>
    </li>
-   <li class="mb-3">
-    IBM Go Fork für Mainframes:
-    <a class="underline hover:no-underline" href="https://github.com/linux-on-ibm-z/go" rel="nofollow">
+   <li>
+    <span>
+     IBM Go Fork für Mainframes:
+    </span>
+    <a href="https://github.com/linux-on-ibm-z/go" rel="nofollow">
      https://github.com/linux-on-ibm-z/go
     </a>
    </li>
-   <li class="mb-3">
-    DB4O:
-    <a class="underline hover:no-underline" href="https://de.wikipedia.org/wiki/Db4o" rel="nofollow">
+   <li>
+    <span>
+     DB4O:
+    </span>
+    <a href="https://de.wikipedia.org/wiki/Db4o" rel="nofollow">
      https://de.wikipedia.org/wiki/Db4o
     </a>
    </li>
-   <li class="mb-3">
-    Michael Stonebraker / The End of an Architectural Era (It’s Time for a Complete Rewrite):
-    <a class="underline hover:no-underline" href="http://nms.csail.mit.edu/~stavros/pubs/hstore.pdf" rel="nofollow">
+   <li>
+    <span>
+     Michael Stonebraker / The End of an Architectural Era (It’s Time for a Complete Rewrite):
+    </span>
+    <a href="http://nms.csail.mit.edu/~stavros/pubs/hstore.pdf" rel="nofollow">
      http://nms.csail.mit.edu/~stavros/pubs/hstore.pdf
     </a>
    </li>
-   <li class="mb-3">
-    Percona:
-    <a class="underline hover:no-underline" href="https://www.percona.com/" rel="nofollow">
+   <li>
+    <span>
+     Percona:
+    </span>
+    <a href="https://www.percona.com/" rel="nofollow">
      https://www.percona.com/
     </a>
    </li>
-   <li class="mb-3">
-    2ndquadrant:
-    <a class="underline hover:no-underline" href="https://www.2ndquadrant.com/" rel="nofollow">
+   <li>
+    <span>
+     2ndquadrant:
+    </span>
+    <a href="https://www.2ndquadrant.com/" rel="nofollow">
      https://www.2ndquadrant.com/
     </a>
    </li>
-   <li class="mb-3">
-    OSS Names:
-    <a class="underline hover:no-underline" href="https://github.com/EngineeringKiosk/OSS-Names" rel="nofollow">
+   <li>
+    <span>
+     OSS Names:
+    </span>
+    <a href="https://github.com/EngineeringKiosk/OSS-Names" rel="nofollow">
      https://github.com/EngineeringKiosk/OSS-Names
     </a>
    </li>
-   <li class="mb-3">
-    Redis:
-    <a class="underline hover:no-underline" href="https://github.com/redis/redis" rel="nofollow">
+   <li>
+    <span>
+     Redis:
+    </span>
+    <a href="https://github.com/redis/redis" rel="nofollow">
      https://github.com/redis/redis
     </a>
    </li>
-   <li class="mb-3">
-    RedisLabs:
-    <a class="underline hover:no-underline" href="https://redis.com/" rel="nofollow">
+   <li>
+    <span>
+     RedisLabs:
+    </span>
+    <a href="https://redis.com/" rel="nofollow">
      https://redis.com/
     </a>
    </li>
-   <li class="mb-3">
-    antirez:
-    <a class="underline hover:no-underline" href="http://antirez.com/" rel="nofollow">
+   <li>
+    <span>
+     antirez:
+    </span>
+    <a href="http://antirez.com/" rel="nofollow">
      http://antirez.com/
     </a>
    </li>
-   <li class="mb-3">
-    RocksDB:
-    <a class="underline hover:no-underline" href="http://rocksdb.org/" rel="nofollow">
+   <li>
+    <span>
+     RocksDB:
+    </span>
+    <a href="http://rocksdb.org/" rel="nofollow">
      http://rocksdb.org/
     </a>
    </li>
-   <li class="mb-3">
-    ElasticSearch:
-    <a class="underline hover:no-underline" href="https://github.com/elastic/elasticsearch" rel="nofollow">
+   <li>
+    <span>
+     ElasticSearch:
+    </span>
+    <a href="https://github.com/elastic/elasticsearch" rel="nofollow">
      https://github.com/elastic/elasticsearch
     </a>
    </li>
-   <li class="mb-3">
-    LevelDB:
-    <a class="underline hover:no-underline" href="https://github.com/google/leveldb" rel="nofollow">
+   <li>
+    <span>
+     LevelDB:
+    </span>
+    <a href="https://github.com/google/leveldb" rel="nofollow">
      https://github.com/google/leveldb
     </a>
    </li>
-   <li class="mb-3">
-    MyRocks:
-    <a class="underline hover:no-underline" href="http://myrocks.io/" rel="nofollow">
+   <li>
+    <span>
+     MyRocks:
+    </span>
+    <a href="http://myrocks.io/" rel="nofollow">
      http://myrocks.io/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00:00) Intro
+  <p>
+   <span>
+    (00:00:00) Intro
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00:55) Mathematik-Professoren und Kürbiskern-Brötchen
+  <p>
+   <span>
+    (00:00:55) Mathematik-Professoren und Kürbiskern-Brötchen
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:02:27) Warum Datenbanken ein Herzensthema von Wolfgang ist
+  <p>
+   <span>
+    (00:02:27) Warum Datenbanken ein Herzensthema von Wolfgang ist
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:04:08) Was ist denn eine Datenbank und wann verwendet man eine Datenbank?
+  <p>
+   <span>
+    (00:04:08) Was ist denn eine Datenbank und wann verwendet man eine Datenbank?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:06:34) Sind klassische Dateien auch eine Datenbank?
+  <p>
+   <span>
+    (00:06:34) Sind klassische Dateien auch eine Datenbank?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:07:25) Hierarchische Datenbanksysteme: IBM IMS
+  <p>
+   <span>
+    (00:07:25) Hierarchische Datenbanksysteme: IBM IMS
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:09:30) IBM Mainframes, Go, Docker und horizontale Skalierung
+  <p>
+   <span>
+    (00:09:30) IBM Mainframes, Go, Docker und horizontale Skalierung
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:11:30) Was wäre ein Use-Case von hierarchische und Objekt-Orientierte Datenbanken?
+  <p>
+   <span>
+    (00:11:30) Was wäre ein Use-Case von hierarchische und Objekt-Orientierte Datenbanken?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:16:15) Hast du bereits eine Objekt-Orientierte Datenbanken bereits in einem Projekt eingesetzt?
+  <p>
+   <span>
+    (00:16:15) Hast du bereits eine Objekt-Orientierte Datenbanken bereits in einem Projekt eingesetzt?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:16:52) Trennung von Daten und Applikationslogik und SQL als Basis-Datenbanken-Wissen
+  <p>
+   <span>
+    (00:16:52) Trennung von Daten und Applikationslogik und SQL als Basis-Datenbanken-Wissen
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:18:55) Was ist der Unterschied von SQL-Datenbanken und Dateien
+  <p>
+   <span>
+    (00:18:55) Was ist der Unterschied von SQL-Datenbanken und Dateien
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:19:32) Datenbank Index/Indize: Daten-Duplikation, Lese- und Schreibzugriffe
+  <p>
+   <span>
+    (00:19:32) Datenbank Index/Indize: Daten-Duplikation, Lese- und Schreibzugriffe
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:23:54) Ist eine Excel-Datei eine Datenbank?
+  <p>
+   <span>
+    (00:23:54) Ist eine Excel-Datei eine Datenbank?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:24:58) Unterschied von Files und Datenbanken: Nutzung von mehreren Benutzern
+  <p>
+   <span>
+    (00:24:58) Unterschied von Files und Datenbanken: Nutzung von mehreren Benutzern
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:28:03) Recovery, persistentes und konsistentes Speichern bei Files und Datenbanken
+  <p>
+   <span>
+    (00:28:03) Recovery, persistentes und konsistentes Speichern bei Files und Datenbanken
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:31:01) Relationale Datenbanken sind die eigentlich klassischen Datenbanken
+  <p>
+   <span>
+    (00:31:01) Relationale Datenbanken sind die eigentlich klassischen Datenbanken
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:34:31) Proprietäre Datenbanken: Oracle Migration nach PostgreSQL
+  <p>
+   <span>
+    (00:34:31) Proprietäre Datenbanken: Oracle Migration nach PostgreSQL
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:37:06) Oracle Cloud und das Free-Tier
+  <p>
+   <span>
+    (00:37:06) Oracle Cloud und das Free-Tier
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:38:29) MySQL wurde von Oracle übernommen und MariaDB als Alternative
+  <p>
+   <span>
+    (00:38:29) MySQL wurde von Oracle übernommen und MariaDB als Alternative
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:39:48) Logik in der Datenbank, Oracle-Migrationen und Application-Server
+  <p>
+   <span>
+    (00:39:48) Logik in der Datenbank, Oracle-Migrationen und Application-Server
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:41:10) Gibt es ein Killer-Argument für proprietäre Datenbanken?
+  <p>
+   <span>
+    (00:41:10) Gibt es ein Killer-Argument für proprietäre Datenbanken?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:43:57) Woher kommt der Name MySQL und MariaDB kommt?
+  <p>
+   <span>
+    (00:43:57) Woher kommt der Name MySQL und MariaDB kommt?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:45:19) Ist ElasticSearch eine Datenbank nach der klassischen Definition?
+  <p>
+   <span>
+    (00:45:19) Ist ElasticSearch eine Datenbank nach der klassischen Definition?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:46:38) Ist Redis und andere Key-Value-Stores eine Datenbank?
+  <p>
+   <span>
+    (00:46:38) Ist Redis und andere Key-Value-Stores eine Datenbank?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:48:42) NoSQL ist für Kinder, Feature-Ritis, Einfache Datenbanken und LevelDB / RocksDB und MyRocks
+  <p>
+   <span>
+    (00:48:42) NoSQL ist für Kinder, Feature-Ritis, Einfache Datenbanken und LevelDB / RocksDB und MyRocks
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:53:19) Was sind Spalten-Datenbanken und wann sollten diese angewendet werden? Analytische Datenbanken und Clickhouse von Yandex
+  <p>
+   <span>
+    (00:53:19) Was sind Spalten-Datenbanken und wann sollten diese angewendet werden? Analytische Datenbanken und Clickhouse von Yandex
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:58:15) Was für Fragen sind relevant um die richtige Datenbank für mich zu finden?
+  <p>
+   <span>
+    (00:58:15) Was für Fragen sind relevant um die richtige Datenbank für mich zu finden?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (01:01:43) Feedback zum Thema Datenbanken und Outro
+  <p>
+   <span>
+    (01:01:43) Feedback zum Thema Datenbanken und Outro
+   </span>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <h3>
+   <br/>
+  </h3>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Wolfgang Gassler (
+    </span>
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
-   <li class="mb-3">
-    Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <li>
+    <span>
+     Andy Grunwald (
+    </span>
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Engineering Kiosk Podcast: Anfragen an
+   </span>
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/20-off-boarding-und-on-boarding-wie-verlasse-ich-eine-firma-richtig.md
+++ b/src/pages/podcast/episode/20-off-boarding-und-on-boarding-wie-verlasse-ich-eine-firma-richtig.md
@@ -49,122 +49,134 @@ title: '#20 Off-Boarding und On-Boarding: Wie verlasse ich eine Firma richtig?'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
+<p>
    Firmenwechsel. Kündigung ist raus. Wie gehts weiter?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Offboarding und Onboarding sind i.d.R. zwei Themen die sehr stark unterschätzt werden. Wie sieht man als Mitarbeiter zu, dass bei einem Firmenwechsel keine verbrannte Erde hinterlassen wird? Wie übergibt man alles ordentlich? Warum ist das überhaupt wichtig? Und was ist ein Exit-Gespräch? Und wenn das alles durch ist: Wie startet man bei der neuen Firma ordentlich? Worauf sollte man achten? Und wie kann Onboarding aussehen? Dies und nich viel mehr.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Bonus: Was Peter Thiel mit Kleber zu tun hat, was Krokodile mit Prüfungsergebnissen zu tun hat und was ein Weckmann mit dem Podcast zu tun hat.
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     List of tech migrations:
-    <a class="underline hover:no-underline" href="https://github.com/kokizzu/list-of-tech-migrations" rel="nofollow">
+    <a href="https://github.com/kokizzu/list-of-tech-migrations" rel="nofollow">
      https://github.com/kokizzu/list-of-tech-migrations
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     Ian Goodfellow, Apple KI-Chef, verlässt Unternehmen:
-    <a class="underline hover:no-underline" href="https://www.apfeltalk.de/magazin/news/ian-goodfellow-apple-ki-chef-verlaesst-unternehmen/" rel="nofollow">
+    <a href="https://www.apfeltalk.de/magazin/news/ian-goodfellow-apple-ki-chef-verlaesst-unternehmen/" rel="nofollow">
      https://www.apfeltalk.de/magazin/news/ian-goodfellow-apple-ki-chef-verlaesst-unternehmen/
     </a>
    </li>
-   <li class="mb-3">
+   <li>
     GitLab onboarding:
-    <a class="underline hover:no-underline" href="https://about.gitlab.com/handbook/people-group/general-onboarding/" rel="nofollow">
+    <a href="https://about.gitlab.com/handbook/people-group/general-onboarding/" rel="nofollow">
      https://about.gitlab.com/handbook/people-group/general-onboarding/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:00:00) Intro
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:01:52) Landtagswahl in NRW und das Feedback bei der Briefwahl
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:07:42) Themen-Intro: Offboarding und Onboarding
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:08:42) Wie kommen wir auf das Thema Offboarding und Onboarding
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:10:09) Warum ist das Thema Offboarding und Onboarding relevant ist
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:12:02) Wie lang sollte man bei einer Firma bleiben?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:16:02) Muss man sich jede 2 bis 4 Jahre neu erfinden?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:19:43) Die Definition von Arbeit: Geld gegen Zeit und Fähigkeit und Loyalität zu Firmen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:21:12) Die Goldenen Handschellen durch Equity, Stocks und Firmen-Anteile
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:22:49) Warum ist der Offboarding-Prozess eigentlich wichtig?
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:23:43) Der Offboarding-Prozess aus der Sicht der Firma: Feedback, Exit-Chat, eigenes Netzwerk
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:32:30) Der Offboarding-Prozess aus Sicht eines Mitarbeiter: Verbrannte Erde, Kaffee trinken, Prozesse die failen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:48:00) Die Zeit zwischen Offboarding und der neuen Firma: Urlaub
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (00:50:51) Onboarding in einer neuen Folge: Intro Chats, Dokumentation, Checklisten, Diagramme und dumme Fragen
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
    (01:11:20) Outro
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
+  <ul>
+   <li>
     Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
     )
    </li>
-   <li class="mb-3">
+   <li>
     Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
     )
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
+  <p>
+   <br/>
+  </p>
+  <p>
    Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
    oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/pages/podcast/episode/21-static-site-generators-die-webseite.md
+++ b/src/pages/podcast/episode/21-static-site-generators-die-webseite.md
@@ -46,206 +46,307 @@ title: '#21 Static Site Generators & DIE Webseite'
 
 ---
 
-<p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Statische Websites sind wieder cool und wir springen mit der eigenen Website direkt auf den Hype.
+<p>
+   <span>
+    Statische Websites sind wieder cool und wir springen mit der eigenen Website direkt auf den Hype.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Eine Episode mal in (teilweise) eigener Sache: Nach 6 Monaten und 20 Episoden haben wir eine eigene Website gebaut. Mit einem Static Site Generator. Wieso wir eine eigene Website haben wollen, was wir uns davon erhoffen, wie der technische Unterbau aussieht, wo wir recht dreckige Hacks eingebaut haben, was Static Site Generatoren sind und wozu sie eigentlich gut sind, bei welchen Use-Cases diese nicht geeignet sind und warum ein Produkt-Name zu Weltraum-Ergebnissen bei Google führen kann, klären wir in dieser Episode.
+  <p>
+   <span>
+    Eine Episode mal in (teilweise) eigener Sache: Nach 6 Monaten und 20 Episoden haben wir eine eigene Website gebaut. Mit einem Static Site Generator. Wieso wir eine eigene Website haben wollen, was wir uns davon erhoffen, wie der technische Unterbau aussieht, wo wir recht dreckige Hacks eingebaut haben, was Static Site Generatoren sind und wozu sie eigentlich gut sind, bei welchen Use-Cases diese nicht geeignet sind und warum ein Produkt-Name zu Weltraum-Ergebnissen bei Google führen kann, klären wir in dieser Episode.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Bonus: Was die Toten Hosen, Broilers und Rammstein mit Static Site Generators zu tun haben und wieso Österreich so gut im Marketing ist.
+  <p>
+   <span>
+    Bonus: Was die Toten Hosen, Broilers und Rammstein mit Static Site Generators zu tun haben und wieso Österreich so gut im Marketing ist.
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Feedback an
-   <a class="underline hover:no-underline" href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Feedback an
+   </span>
+   <a href="mailto:stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="links">
+  <p>
+   <br/>
+  </p>
+  <h3 id="links">
    Links
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Prototype.js:
-    <a class="underline hover:no-underline" href="http://prototypejs.org/" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Prototype.js:
+    </span>
+    <a href="http://prototypejs.org/" rel="nofollow">
      http://prototypejs.org/
     </a>
    </li>
-   <li class="mb-3">
-    MooTools:
-    <a class="underline hover:no-underline" href="https://mootools.net/" rel="nofollow">
+   <li>
+    <span>
+     MooTools:
+    </span>
+    <a href="https://mootools.net/" rel="nofollow">
      https://mootools.net/
     </a>
    </li>
-   <li class="mb-3">
-    script.aculo.us:
-    <a class="underline hover:no-underline" href="https://script.aculo.us/" rel="nofollow">
+   <li>
+    <span>
+     script.aculo.us:
+    </span>
+    <a href="https://script.aculo.us/" rel="nofollow">
      https://script.aculo.us/
     </a>
    </li>
-   <li class="mb-3">
-    RedCircle:
-    <a class="underline hover:no-underline" href="https://redcircle.com/" rel="nofollow">
+   <li>
+    <span>
+     RedCircle:
+    </span>
+    <a href="https://redcircle.com/" rel="nofollow">
      https://redcircle.com/
     </a>
    </li>
-   <li class="mb-3">
-    Template Podcast X:
-    <a class="underline hover:no-underline" href="https://webflow.com/templates/html/podcast-x-podcast-website-template" rel="nofollow">
+   <li>
+    <span>
+     Template Podcast X:
+    </span>
+    <a href="https://webflow.com/templates/html/podcast-x-podcast-website-template" rel="nofollow">
      https://webflow.com/templates/html/podcast-x-podcast-website-template
     </a>
    </li>
-   <li class="mb-3">
-    shuffle:
-    <a class="underline hover:no-underline" href="https://shuffle.dev/" rel="nofollow">
+   <li>
+    <span>
+     shuffle:
+    </span>
+    <a href="https://shuffle.dev/" rel="nofollow">
      https://shuffle.dev/
     </a>
    </li>
-   <li class="mb-3">
-    Hugo:
-    <a class="underline hover:no-underline" href="https://gohugo.io/" rel="nofollow">
+   <li>
+    <span>
+     Hugo:
+    </span>
+    <a href="https://gohugo.io/" rel="nofollow">
      https://gohugo.io/
     </a>
    </li>
-   <li class="mb-3">
-    Gatsby:
-    <a class="underline hover:no-underline" href="https://www.gatsbyjs.com/" rel="nofollow">
+   <li>
+    <span>
+     Gatsby:
+    </span>
+    <a href="https://www.gatsbyjs.com/" rel="nofollow">
      https://www.gatsbyjs.com/
     </a>
    </li>
-   <li class="mb-3">
-    Nuxt.js:
-    <a class="underline hover:no-underline" href="https://nuxtjs.org/" rel="nofollow">
+   <li>
+    <span>
+     Nuxt.js:
+    </span>
+    <a href="https://nuxtjs.org/" rel="nofollow">
      https://nuxtjs.org/
     </a>
    </li>
-   <li class="mb-3">
-    Next.js:
-    <a class="underline hover:no-underline" href="https://nextjs.org/" rel="nofollow">
+   <li>
+    <span>
+     Next.js:
+    </span>
+    <a href="https://nextjs.org/" rel="nofollow">
      https://nextjs.org/
     </a>
    </li>
-   <li class="mb-3">
-    Netlify:
-    <a class="underline hover:no-underline" href="https://www.netlify.com/" rel="nofollow">
+   <li>
+    <span>
+     Netlify:
+    </span>
+    <a href="https://www.netlify.com/" rel="nofollow">
      https://www.netlify.com/
     </a>
    </li>
-   <li class="mb-3">
-    Cloudflare Edge Worker:
-    <a class="underline hover:no-underline" href="https://workers.cloudflare.com/" rel="nofollow">
+   <li>
+    <span>
+     Cloudflare Edge Worker:
+    </span>
+    <a href="https://workers.cloudflare.com/" rel="nofollow">
      https://workers.cloudflare.com/
     </a>
    </li>
-   <li class="mb-3">
-    Jamstack:
-    <a class="underline hover:no-underline" href="https://jamstack.org/" rel="nofollow">
+   <li>
+    <span>
+     Jamstack:
+    </span>
+    <a href="https://jamstack.org/" rel="nofollow">
      https://jamstack.org/
     </a>
    </li>
-   <li class="mb-3">
-    Astro:
-    <a class="underline hover:no-underline" href="https://astro.build/" rel="nofollow">
+   <li>
+    <span>
+     Astro:
+    </span>
+    <a href="https://astro.build/" rel="nofollow">
      https://astro.build/
     </a>
    </li>
-   <li class="mb-3">
-    trivago Tech Blog:
-    <a class="underline hover:no-underline" href="https://tech.trivago.com/" rel="nofollow">
+   <li>
+    <span>
+     trivago Tech Blog:
+    </span>
+    <a href="https://tech.trivago.com/" rel="nofollow">
      https://tech.trivago.com/
     </a>
    </li>
-   <li class="mb-3">
-    tailwind:
-    <a class="underline hover:no-underline" href="https://tailwindcss.com/" rel="nofollow">
+   <li>
+    <span>
+     tailwind:
+    </span>
+    <a href="https://tailwindcss.com/" rel="nofollow">
      https://tailwindcss.com/
     </a>
    </li>
-   <li class="mb-3">
-    Carrd:
-    <a class="underline hover:no-underline" href="https://carrd.co/" rel="nofollow">
+   <li>
+    <span>
+     Carrd:
+    </span>
+    <a href="https://carrd.co/" rel="nofollow">
      https://carrd.co/
     </a>
    </li>
   </ul>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="sprungmarken">
+  <p>
+   <br/>
+  </p>
+  <h3 id="sprungmarken">
    Sprungmarken
   </h3>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:00:00) Intro
+  <p>
+   <span>
+    (00:00:00) Intro
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:03:59) Die Engineering Kiosk Website: engineeringkiosk.dev
+  <p>
+   <span>
+    (00:03:59) Die Engineering Kiosk Website: engineeringkiosk.dev
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:04:44) Historische JavaScript-Frameworks: MooTools, Prototype.js und script.aculo.us
+  <p>
+   <span>
+    (00:04:44) Historische JavaScript-Frameworks: MooTools, Prototype.js und script.aculo.us
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:06:40) Andys Agentur-Background
+  <p>
+   <span>
+    (00:06:40) Andys Agentur-Background
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:07:32) Warum braucht der Engineering Kiosk eine Website?
+  <p>
+   <span>
+    (00:07:32) Warum braucht der Engineering Kiosk eine Website?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:14:37) Warum haben wir jetzt erst eine Website?
+  <p>
+   <span>
+    (00:14:37) Warum haben wir jetzt erst eine Website?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:16:06) Die Technik hinter der Engineering Kiosk Website
+  <p>
+   <span>
+    (00:16:06) Die Technik hinter der Engineering Kiosk Website
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:21:00) Was ist ein Static Site Generator?
+  <p>
+   <span>
+    (00:21:00) Was ist ein Static Site Generator?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:31:29) Kritik am Static Site Generator Hugo
+  <p>
+   <span>
+    (00:31:29) Kritik am Static Site Generator Hugo
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:34:56) Welcher Static Site Generator wurde für die Engineering Kiosk Website verwendet?
+  <p>
+   <span>
+    (00:34:56) Welcher Static Site Generator wurde für die Engineering Kiosk Website verwendet?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:39:09) Was ist das coole an Astro und wie wurde Website umgesetzt?
+  <p>
+   <span>
+    (00:39:09) Was ist das coole an Astro und wie wurde Website umgesetzt?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:41:30) Wie bekommen wir die Podcast Episoden in die Website rein?
+  <p>
+   <span>
+    (00:41:30) Wie bekommen wir die Podcast Episoden in die Website rein?
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:46:06) Technischer Unterbau mit Astro, tailwind, Python, Netlify
+  <p>
+   <span>
+    (00:46:06) Technischer Unterbau mit Astro, tailwind, Python, Netlify
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:50:05) Feedback und Contribution zum Engineering Kiosk Website Setup
+  <p>
+   <span>
+    (00:50:05) Feedback und Contribution zum Engineering Kiosk Website Setup
+   </span>
   </p>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   (00:52:29) Outro
+  <p>
+   <span>
+    (00:52:29) Outro
+   </span>
   </p>
-  <h3 class="mb-4 text-2xl md:text-3xl font-semibold text-coolGray-800" id="hosts">
+  <p>
+   <br/>
+  </p>
+  <h3 id="hosts">
    Hosts
   </h3>
-  <ul class="list-disc px-5 mb-6 md:px-5 text-base md:text-lg text-coolGray-500">
-   <li class="mb-3">
-    Wolfgang Gassler (
-    <a class="underline hover:no-underline" href="https://twitter.com/schafele" rel="nofollow">
+  <ul>
+   <li>
+    <span>
+     Wolfgang Gassler (
+    </span>
+    <a href="https://twitter.com/schafele" rel="nofollow">
      https://twitter.com/schafele
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
-   <li class="mb-3">
-    Andy Grunwald (
-    <a class="underline hover:no-underline" href="https://twitter.com/andygrunwald" rel="nofollow">
+   <li>
+    <span>
+     Andy Grunwald (
+    </span>
+    <a href="https://twitter.com/andygrunwald" rel="nofollow">
      https://twitter.com/andygrunwald
     </a>
-    )
+    <span>
+     )
+    </span>
    </li>
   </ul>
-  <p class="mb-6 text-base md:text-lg text-coolGray-500">
-   Engineering Kiosk Podcast: Anfragen an
-   <a class="underline hover:no-underline" href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
+  <p>
+   <br/>
+  </p>
+  <p>
+   <span>
+    Engineering Kiosk Podcast: Anfragen an
+   </span>
+   <a href="http://stehtisch@engineeringkiosk.dev" rel="nofollow">
     stehtisch@engineeringkiosk.dev
    </a>
-   oder via Twitter an
-   <a class="underline hover:no-underline" href="https://twitter.com/EngKiosk" rel="nofollow">
+   <span>
+    oder via Twitter an
+   </span>
+   <a href="https://twitter.com/EngKiosk" rel="nofollow">
     https://twitter.com/EngKiosk
    </a>
   </p>

--- a/src/styles/podcast_episode.scss
+++ b/src/styles/podcast_episode.scss
@@ -1,0 +1,40 @@
+/**
+Used to style a single podcast episode.
+*/
+
+
+#slot {
+    p {
+        @apply mb-6;
+        @apply text-base;
+        @apply md:text-lg;
+        @apply text-coolGray-500;
+    }
+
+    h3 {
+        @apply mb-4;
+        @apply text-2xl;
+        @apply md:text-3xl;
+        @apply font-semibold;
+        @apply text-coolGray-800;
+    }
+
+    ul {
+        @apply list-disc;
+        @apply px-5;
+        @apply mb-6;
+        @apply md:px-5;
+        @apply text-base;
+        @apply md:text-lg;
+        @apply text-coolGray-500;
+    }
+
+    li {
+        @apply mb-3;
+    }
+
+    a {
+        @apply underline;
+        @apply hover:no-underline;
+    }
+}


### PR DESCRIPTION
This Pull Requests removes the hacky HTML parsing and tailwind CSS class assignment from the python script.
The CSS class assignment runs now implicit via SCSS.

However, it has one tradeoff:
The RedCircle RTE adds things like <p><br></p> which leads to additional space between between the headlines (see screenshot).

Before:
![Screenshot from 2022-06-06 08-26-54](https://user-images.githubusercontent.com/320064/172107148-37e99c56-b41d-4883-8e9c-aeb61cd8454b.png)

-----------

After:
![Screenshot from 2022-06-06 08-27-02](https://user-images.githubusercontent.com/320064/172107144-c6de642b-5ee4-4037-baad-291986ebe411.png)

I think there are two possible solutions:

1. We accept the additional whitespace (not a big deal)
2. We edit the red circle rte content with particular focus on skipping the additional whitespace