### PR TITLE
Add basic Astro build testing as GitHub Actions workflow

### DIFF
--- a/.github/workflows/astro-build.yml
+++ b/.github/workflows/astro-build.yml
@@ -1,0 +1,27 @@
+name: Test of Astro build
+
+on:
+  push:
+  schedule:
+    - cron: "5 1 * * *" # Run nightly
+  workflow_dispatch:
+
+jobs:
+  testing:
+    name: Astro build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Run make init
+        run: make init
+
+      - name: Run make clean
+        run: make clean
+
+      - name: Run make build
+        run: make build


### PR DESCRIPTION
This ensures that we always can build our site.

Nightly testing is included ensuring that no external dependency breaks.