### PR TITLE
Upgrade deezer-python lib and use link attribute of podcast episode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/scripts"
+    schedule:
+      interval: "daily"

--- a/scripts/podcast-feed-to-content.py
+++ b/scripts/podcast-feed-to-content.py
@@ -512,11 +512,7 @@ def get_episode_link_from_deezer(episodes, title: str) -> str:
     u = ""
     for episode in episodes:
         if episode.title == title:
-            # Here we should have a property "episode.link"
-            # but somehow this is not available.
-            # See https://github.com/browniebroke/deezer-python/issues/536
-            # As a workaround, we craft the link ourself.
-            u = f"https://www.deezer.com/de/episode/{episode.id}"
+            u = episode.link
 
     return u
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,5 +7,5 @@ toml == 0.10.2
 lxml == 4.9.1
 spotipy == 2.20
 Pillow == 9.1.1
-deezer-python == 5.3.3
+deezer-python == 5.5.0
 gitpython == 3.1.20


### PR DESCRIPTION
This bug was fixed in https://github.com/browniebroke/deezer-python/issues/536