### PR TITLE
Fix sorting parameter: Rename `date` to `pubDate`

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,12 +14,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 // Data Fetching: List all Markdown posts in the repo.
 let allPosts = await Astro.glob('./blog/post/*.mdx');
-allPosts.sort((a, b) => new Date(b.frontmatter.date).valueOf() - new Date(a.frontmatter.date).valueOf());
+allPosts.sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf());
 
 // Determine the latest episode
 // We have places where the last episode is linked
 let allEpisodes = await Astro.glob('../pages/podcast/episode/*.md');
-allEpisodes.sort((a, b) => new Date(b.frontmatter.date).valueOf() - new Date(a.frontmatter.date).valueOf());
+allEpisodes.sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf());
 let episodesToShow = allEpisodes.slice(0, 1);
 let episode = episodesToShow[0];
 

--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -49,10 +49,10 @@ if(tagInfo.hasOwnProperty(tagHumanName)){
 }
 
 // Filter blog posts by tag, sort by date
-const blogPosts = allBlogPosts.filter((post) => post.frontmatter.tags.includes(tagHumanName)).sort((a, b) => new Date(b.frontmatter.date).valueOf() - new Date(a.frontmatter.date).valueOf());
+const blogPosts = allBlogPosts.filter((post) => post.frontmatter.tags.includes(tagHumanName)).sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf());
 
 // Filter podcast episodes by tag, sort by date
-const podcastEpisodes = allPodcastEpisode.filter((episode) => episode.frontmatter.tags.includes(tagHumanName)).sort((a, b) => new Date(b.frontmatter.date).valueOf() - new Date(a.frontmatter.date).valueOf());
+const podcastEpisodes = allPodcastEpisode.filter((episode) => episode.frontmatter.tags.includes(tagHumanName)).sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf());
 
 ---
 


### PR DESCRIPTION
This rename operations was mainly done due to the Astro RSS plugin. We forgot a few places