### PR TITLE
Profile page: Moved image to the top and social links next to the tag

### DIFF
--- a/src/pages/kiosk-betreiber/andy-grunwald.astro
+++ b/src/pages/kiosk-betreiber/andy-grunwald.astro
@@ -20,27 +20,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 			<section class="py-24 md:py-32 bg-white overflow-hidden" style="background-image: url('/images/elements/pattern-white.svg'); background-position: center;">
 				<div class="container px-4 mx-auto">
-					<div class="flex flex-wrap lg:items-center -mx-4">
+					<div class="flex flex-wrap lg:items-start -mx-4">
 						<div class="w-full md:w-1/2 px-4 mb-16 md:mb-0">
-							<span class="inline-block py-px px-2 mb-4 text-xs leading-5 text-yellow-500 bg-yellow-100 font-medium uppercase rounded-full shadow-sm">
-								Der aus dem Ruhrpott
-							</span>
-							<h1 class="mb-8 text-4xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tighter">
-								Andy Grunwald
-							</h1>
-							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
-								Engineering Manager im Bereich <i>Site Reliability Engineering</i> und Software Engineer mit einem Fokus auf Backend-Systeme, Infrastruktur und Engineering Kultur.
-								Zieht seine Motivation aus der Team-Arbeit mit Menschen, die motiviert sind und etwas nach vorne bringen wollen (<i>Do awesome things with awesome people</i>).
-								Wohnt mittem im Ruhrgebiet, in Duisburg (und will das auch) 👷
-							</p>
-							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
-								Langjähriger Open-Source Contributor und Hobby- (bzw. eher Möchtegern)-Landwirt 🧑‍🌾
-								Mag es, seine Grenzen beim Functional Fitness auszuloten und die Freizeit mit seinem Hund zu verbringen.
-							</p>
-							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
-								Neben dem <a href="/">Engineering Kiosk</a> betreibt Andy mit <a href="https://app.sourcectl.dev/" class="underline hover:no-underline">sourcectl</a> eine Plattform die Open Source-Kultur sowie Inner Source innerhalb von Firmen zu pushen.
-							</p>
-							<div class="flex items-center ">
+							<div class="flex items-center mb-4">
+								<span class="inline-block mr-6 py-px px-2 text-xs leading-5 text-yellow-500 bg-yellow-100 font-medium uppercase rounded-full shadow-sm">
+									Der aus dem Ruhrpott
+								</span>
 								<a class="inline-block mr-6 hover:opacity-80" href="https://github.com/andygrunwald">
 									<img src="/images/brands/github-gray.svg" alt="Andy Grunwald auf GitHub">
 								</a>
@@ -54,6 +39,21 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 									<img src="/images/elements/icon-website.svg" height="33" width="33" alt="Website von Andy Grunwald">
 								</a>
 							</div>
+							<h1 class="mb-6 text-4xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tighter">
+								Andy Grunwald
+							</h1>
+							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
+								Engineering Manager im Bereich <i>Site Reliability Engineering</i> und Software Engineer mit einem Fokus auf Backend-Systeme, Infrastruktur und Engineering Kultur.
+								Zieht seine Motivation aus der Team-Arbeit mit Menschen, die motiviert sind und etwas nach vorne bringen wollen (<i>Do awesome things with awesome people</i>).
+								Wohnt mittem im Ruhrgebiet, in Duisburg (und will das auch) 👷
+							</p>
+							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
+								Langjähriger Open-Source Contributor und Hobby- (bzw. eher Möchtegern)-Landwirt 🧑‍🌾
+								Mag es, seine Grenzen beim Functional Fitness auszuloten und die Freizeit mit seinem Hund zu verbringen.
+							</p>
+							<p class="text-lg md:text-xl text-coolGray-500 font-medium">
+								Neben dem <a href="/">Engineering Kiosk</a> betreibt Andy mit <a href="https://app.sourcectl.dev/" class="underline hover:no-underline">sourcectl</a> eine Plattform die Open Source-Kultur sowie Inner Source innerhalb von Firmen zu pushen.
+							</p>
 						</div>
 						<div class="w-full md:w-1/2 px-4">
 							<div class="relative mx-auto md:mr-0 max-w-max">

--- a/src/pages/kiosk-betreiber/andy-grunwald.astro
+++ b/src/pages/kiosk-betreiber/andy-grunwald.astro
@@ -48,7 +48,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 									<img src="/images/brands/twitter.svg" alt="Andy Grunwald auf twitter">
 								</a>
 								<a class="inline-block mr-6 hover:opacity-80" href="https://linkedin.com/in/andy-grunwald-09aa265a">
-									<img src="/images/brands/linkedin.svg" alt="Andy Grunwad auf LinkedIn">
+									<img src="/images/brands/linkedin.svg" alt="Andy Grunwald auf LinkedIn">
 								</a>
 								<a class="inline-block hover:opacity-80" href="https://andygrunwald.com/">
 									<img src="/images/elements/icon-website.svg" height="33" width="33" alt="Website von Andy Grunwald">

--- a/src/pages/kiosk-betreiber/wolfgang-gassler.astro
+++ b/src/pages/kiosk-betreiber/wolfgang-gassler.astro
@@ -20,7 +20,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 			<section class="py-24 md:py-32 bg-white overflow-hidden" style="background-image: url('/images/elements/pattern-white.svg'); background-position: center;">
 				<div class="container px-4 mx-auto">
-					<div class="flex flex-wrap lg:items-center -mx-4">
+					<div class="flex flex-wrap lg:items-start -mx-4">
 						<div class="w-full md:w-1/2 px-4 mb-16 md:mb-0">
 							<div class="relative mx-auto md:ml-0 max-w-max">
 								<img class="absolute z-10 -left-8 -top-8 w-28 md:w-auto text-yellow-400" src="/images/elements/circle3-red.svg" alt="Roter Kreis">
@@ -29,27 +29,10 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 							</div>
 						</div>
 						<div class="w-full md:w-1/2 px-4">
-							<span class="inline-block py-px px-2 mb-4 text-xs leading-5 text-yellow-500 bg-yellow-100 font-medium uppercase rounded-full shadow-sm">
-								Der aus den Bergen
-							</span>
-							<h1 class="mb-8 text-4xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tighter">
-								Wolfgang Gassler
-							</h1>
-							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
-								<a href="https://gassler.org/consulting" class="underline hover:no-underline">Freelancer und Consultant</a> mit Interesse an Menschen, Tech &amp; Team-Kultur, Datenbank und Skalierung, Produkt Entwicklung und Usability sowie Recommender Systeme.
-								Ehemals Engineering Manager bei <a href="https://company.trivago.com/" class="underline hover:no-underline">trivago</a> und auch viele Jahre in Lehre &amp; Forschung in der <a href="https://dbis-informatik.uibk.ac.at/" class="underline hover:no-underline">Forschungsgruppe Datenbanken und Informationssysteme an der Universität Innsbruck (Österreich)</a>.
-								Gerne unterwegs (auch weit weg von den Bergen 🌊 ).
-								Ursprünglich aus Innsbruck (ganz nah an den Bergen ⛰️ ).
-							</p>
-							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
-								Freiwilliger Feuerwehrmann und leidenschaftlicher Kletterer.
-								Verbringt einen Großteil seiner Freizeit in der Natur und in Zügen, um die Welt zu sehen.
-								Legt sehr viel Wert auf geselliges Essen. 
-							</p>
-							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
-								Neben dem <a href="/">Engineering Kiosk</a> betreibt Wolfgang mit Freunden als Side Project <a href="https://www.f-online.app/" class="underline hover:no-underline">F-Online.at</a>, die größte E-Learning Plattform für die österreichische Führerscheinprüfung.
-							</p>
-							<div class="flex items-center ">
+							<div class="flex items-center mb-4">
+								<span class="inline-block mr-6 py-px px-2 text-xs leading-5 text-yellow-500 bg-yellow-100 font-medium uppercase rounded-full shadow-sm">
+									Der aus den Bergen
+								</span>
 								<a class="inline-block mr-6 hover:opacity-80" href="https://github.com/woolfg">
 									<img src="/images/brands/github-gray.svg" alt="Wolfgang Gassler auf GitHub">
 								</a>
@@ -63,6 +46,23 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 									<img src="/images/elements/icon-website.svg" height="33" width="33" alt="Website von Wolfgang Gassler">
 								</a>
 							</div>
+							<h1 class="mb-6 text-4xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tighter">
+								Wolfgang Gassler
+							</h1>
+							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
+								<a href="https://gassler.org/consulting" class="underline hover:no-underline">Freelancer und Consultant</a> mit Interesse an Menschen, Tech &amp; Team-Kultur, Datenbank und Skalierung, Produkt Entwicklung und Usability sowie Recommender Systeme.
+								Ehemals Engineering Manager bei <a href="https://company.trivago.com/" class="underline hover:no-underline">trivago</a> und auch viele Jahre in Lehre &amp; Forschung in der <a href="https://dbis-informatik.uibk.ac.at/" class="underline hover:no-underline">Forschungsgruppe Datenbanken und Informationssysteme an der Universität Innsbruck (Österreich)</a>.
+								Gerne unterwegs (auch weit weg von den Bergen 🌊 ).
+								Ursprünglich aus Innsbruck (ganz nah an den Bergen ⛰️ ).
+							</p>
+							<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
+								Freiwilliger Feuerwehrmann und leidenschaftlicher Kletterer.
+								Verbringt einen Großteil seiner Freizeit in der Natur und in Zügen, um die Welt zu sehen.
+								Legt sehr viel Wert auf geselliges Essen. 
+							</p>
+							<p class="text-lg md:text-xl text-coolGray-500 font-medium">
+								Neben dem <a href="/">Engineering Kiosk</a> betreibt Wolfgang mit Freunden als Side Project <a href="https://www.f-online.app/" class="underline hover:no-underline">F-Online.at</a>, die größte E-Learning Plattform für die österreichische Führerscheinprüfung.
+							</p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Old

<img width="1508" alt="Screenshot 2023-02-12 at 15 04 22" src="https://user-images.githubusercontent.com/320064/218315734-9c662a5e-3ebe-420f-ab8a-8e64089f579a.png">

## New

<img width="1503" alt="Screenshot 2023-02-12 at 15 04 05" src="https://user-images.githubusercontent.com/320064/218315731-04fb2918-ec82-4a67-b75f-587368e9c461.png">
