### PR TITLE
Header: Add Apple ID Metatag for Apple Podcast Banner on iOS devices

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -35,6 +35,8 @@ if (ogType) {
 
 <link rel="alternate" type="application/rss+xml" title="RSS Feed vom Engineering Kiosk" href="/rss.xml" />
 
+<meta name="apple-itunes-app" content="app-id=1603082924" />
+
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">


### PR DESCRIPTION
Optimization for Safari / iOS devices