### PR TITLE
Add Verification to the Mastodon link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -59,7 +59,7 @@ const year = new Date().getFullYear();
 						</a>
 					</li>
 					<li class="mb-4">
-						<a class="inline-block text-coolGray-500 hover:text-coolGray-600 font-medium" href="https://podcasts.social/@engkiosk" title="Engineering Kiosk auf Mastodon (@engkiosk@podcasts.social)">
+						<a class="inline-block text-coolGray-500 hover:text-coolGray-600 font-medium" rel="me" href="https://podcasts.social/@engkiosk" title="Engineering Kiosk auf Mastodon (@engkiosk@podcasts.social)">
 							<img src="/images/brands/mastodon_purple.svg" class="inline w-6 mr-2" alt="Mastodon logo" title="Mastodon logo" /> Mastodon
 						</a>
 					</li>


### PR DESCRIPTION
Add a rel="me" to the href, like it is descripted [here](https://joinmastodon.org/verification).

You already link from a field in your [Mastodon profile](https://podcasts.social/@engkiosk) to your website. There is also a link back to the Mastodon profile. With this little change the field at Mastodon should get a :heavy_check_mark: for verification.

I wasn't able to test my change locally (`make init` & `make run`), because my Distro has only a very old version of nodejs in the repository. I hope that very little change does not break anything. 