### PR TITLE
Podcas player: Disable loading of full RSS feed

### DIFF
--- a/src/layouts/podcast-episode.astro
+++ b/src/layouts/podcast-episode.astro
@@ -119,6 +119,9 @@ const html = (await Astro.slots.render('default'))
 					SubscribeBar: {
 						disabled: true,
 					},
+					Playlist: {
+						disabled: true,
+					},
 				},
 				podcast: {
 					title: podcastInfo.title,


### PR DESCRIPTION
This PR disabled the necessary to load the full RSS feed.
By doing this, we loose the "Playlist" feature of the player (the red icon in the picture)

<img width="628" alt="Screenshot 2023-10-28 at 13 40 29" src="https://github.com/EngineeringKiosk/webpage/assets/320064/47983ef5-9942-479f-a3af-d00bbec9b9d0">

Fixes https://github.com/EngineeringKiosk/webpage/issues/592