### PR TITLE
Index: Make the text of the podcast start on the top, not in the center

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,7 +56,7 @@ let currentEpisodeDescription = cutText(episode.data.description, 170);
 			<section class="relative bg-white overflow-hidden" style="background-image: url('/images/elements/pattern-white.svg'); background-position: center;">
 				<div class="py-20 md:py-28">
 					<div class="container px-4 mx-auto">
-						<div class="flex flex-wrap xl:items-center -mx-4">
+						<div class="flex flex-wrap xl:items-start -mx-4">
 							<div class="w-full md:w-1/2 px-4 mb-16 md:mb-0">
 								<h1>
 									<div>


### PR DESCRIPTION
The test of the index page next to the lounge image starts in the center of the image.
This PR switches this to start from the top.