### PR TITLE
Podcast Episode view: Fix clickable chapter when HTML is malformed by Rich Text Editor

### DIFF
--- a/src/layouts/podcast-episode.astro
+++ b/src/layouts/podcast-episode.astro
@@ -95,8 +95,12 @@ let tags = frontmatter.tags.map((element) => URLify(element));
 // However, the spacing doesn't look good in web.
 // Hence we need to make it look good ;)
 const html = (await Astro.slots.render('default'))
-	//remove all <p><br></p>
+	// remove all <p><br></p>
 	.replace(/<p><br><\/p>/g, '')
+	// The Rich Text Editor of RedCircle introduces sometimes <p><span> and not only a <p>
+	// We aim to fix this here (in a dirty way)
+	.replace(/<p><span>/g, '<p>')
+	.replace(/<\/span><\/p>/g, '</p>')
 	// add class + data attribute to p tag of format "<p>(01:18:00)"
 	.replace(/<p>(\(\d\d:\d\d:\d\d\))/g, function (match, capture) {
 		return '<p class="timestamp" data-chapter-start="' + humanTimestampToSecondsTo(capture) + '">' + capture;


### PR DESCRIPTION
Chapters are not clickable in https://engineeringkiosk.dev/podcast/episode/101-observability-und-opentelemetry-mit-severin-neumann/, but in https://engineeringkiosk.dev/podcast/episode/105-cloud-ausfallsicherheit-die-realit%C3%A4t-von-regionen-und-availability-zones/

This Pull Request makes the chapter clickable everywhere.