### PR TITLE
Unify episode path flags: use flagEpisodesStorePath everywhere

### DIFF
--- a/website-admin/cmd/cmd_env.go
+++ b/website-admin/cmd/cmd_env.go
@@ -13,7 +13,6 @@ const (
 	EnvVarTranscriptPath                = "WEBSITEADMIN_TRANSCRIPT_PATH"
 	EnvVarImagesPath                    = "WEBSITEADMIN_IMAGES_PATH"
 	EnvVarNetlifyRedirectTomlFile       = "WEBSITEADMIN_NETLIFY_REDIRECT_TOML_FILE"
-	EnvVarNetlifyRedirectEpisodesDir    = "WEBSITEADMIN_NETLIFY_REDIRECT_EPISODES_DIR"
 	EnvVarNetlifyRedirectRedirectPrefix = "WEBSITEADMIN_NETLIFY_REDIRECT_REDIRECT_PREFIX"
 )
 
@@ -23,7 +22,6 @@ var environmentVariables = map[string]string{
 	EnvVarTranscriptPath:                "Path to store podcast transcripts",
 	EnvVarImagesPath:                    "Path to store podcast images",
 	EnvVarNetlifyRedirectTomlFile:       "Path to netlify.toml file for redirects",
-	EnvVarNetlifyRedirectEpisodesDir:    "Directory containing episode markdown files",
 	EnvVarNetlifyRedirectRedirectPrefix: "Prefix for redirect URLs",
 }
 
@@ -42,7 +40,6 @@ Checked environment variables:
   WEBSITEADMIN_TRANSCRIPT_PATH            Path to store podcast transcripts
   WEBSITEADMIN_IMAGES_PATH                Path to store podcast images
   WEBSITEADMIN_NETLIFY_REDIRECT_TOML_FILE Path to netlify.toml for redirects
-  WEBSITEADMIN_NETLIFY_REDIRECT_EPISODES_DIR  Directory containing episode files
   WEBSITEADMIN_NETLIFY_REDIRECT_REDIRECT_PREFIX  Prefix for redirect URLs
 
 Behavior:

--- a/website-admin/cmd/cmd_podcast_check_player_urls.go
+++ b/website-admin/cmd/cmd_podcast_check_player_urls.go
@@ -61,7 +61,7 @@ This command is useful for:
 func init() {
 	podcastCmd.AddCommand(podcastCheckPlayerURLsCmd)
 
-	podcastCheckPlayerURLsCmd.Flags().StringVarP(&flagPodcastEpisodesPath, "episodes-dir", "e", os.Getenv(EnvVarNetlifyRedirectEpisodesDir), environmentVariables[EnvVarNetlifyRedirectEpisodesDir])
+	podcastCheckPlayerURLsCmd.Flags().StringVarP(&flagEpisodesStorePath, "episodes-dir", "e", os.Getenv(EnvVarEpisodesStorePath), environmentVariables[EnvVarEpisodesStorePath])
 }
 
 func RunPodcastCheckPlayerURLsCmd(cmd *cobra.Command, args []string) error {
@@ -71,7 +71,7 @@ func RunPodcastCheckPlayerURLsCmd(cmd *cobra.Command, args []string) error {
 		Msg("starting")
 
 	// Set default if not provided
-	episodesDir := flagPodcastEpisodesPath
+	episodesDir := flagEpisodesStorePath
 	if episodesDir == "" {
 		episodesDir = "src/content/podcast"
 	}

--- a/website-admin/cmd/cmd_podcast_netlify_redirect.go
+++ b/website-admin/cmd/cmd_podcast_netlify_redirect.go
@@ -90,9 +90,8 @@ Behavior:
 func init() {
 	podcastCmd.AddCommand(podcastNetlifyRedirectCmd)
 
-	// TODO Unify parameters
 	podcastNetlifyRedirectCmd.Flags().StringVarP(&flagNetlifyRedirectTomlFile, "toml-file", "t", os.Getenv(EnvVarNetlifyRedirectTomlFile), environmentVariables[EnvVarNetlifyRedirectTomlFile])
-	podcastNetlifyRedirectCmd.Flags().StringVarP(&flagNetlifyRedirectEpisodesPath, "episodes-dir", "e", os.Getenv(EnvVarNetlifyRedirectEpisodesDir), environmentVariables[EnvVarNetlifyRedirectEpisodesDir])
+	podcastNetlifyRedirectCmd.Flags().StringVarP(&flagEpisodesStorePath, "episodes-dir", "e", os.Getenv(EnvVarEpisodesStorePath), environmentVariables[EnvVarEpisodesStorePath])
 	podcastNetlifyRedirectCmd.Flags().StringVarP(&flagNetlifyRedirectRedirectPrefix, "redirect-prefix", "r", os.Getenv(EnvVarNetlifyRedirectRedirectPrefix), environmentVariables[EnvVarNetlifyRedirectRedirectPrefix])
 }
 
@@ -104,12 +103,12 @@ func RunPodcastNetlifyRedirectCmd(cmd *cobra.Command, args []string) error {
 
 	logger.Info().
 		Str("tomlFile", flagNetlifyRedirectTomlFile).
-		Str("episodesDir", flagNetlifyRedirectEpisodesPath).
+		Str("episodesDir", flagEpisodesStorePath).
 		Msg("Generating podcast netlify redirects")
 
 	// Adjust paths
 	fileToParse := utils.BuildCorrectFilePath(flagNetlifyRedirectTomlFile)
-	flagNetlifyRedirectEpisodesPath = utils.BuildCorrectFilePath(flagNetlifyRedirectEpisodesPath)
+	flagEpisodesStorePath = utils.BuildCorrectFilePath(flagEpisodesStorePath)
 
 	// Read existing TOML file
 	var config NetlifyConfig
@@ -134,7 +133,7 @@ func RunPodcastNetlifyRedirectCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get existing podcast episodes
-	entries, err := os.ReadDir(flagNetlifyRedirectEpisodesPath)
+	entries, err := os.ReadDir(flagEpisodesStorePath)
 	if err != nil {
 		return fmt.Errorf("failed to read episodes directory: %w", err)
 	}

--- a/website-admin/cmd/flags.go
+++ b/website-admin/cmd/flags.go
@@ -11,12 +11,7 @@ var (
 
 	// Netlify Redirects
 	flagNetlifyRedirectTomlFile       string
-	flagNetlifyRedirectEpisodesPath   string
 	flagNetlifyRedirectRedirectPrefix string
-
-	// Podcast
-	// TODO Unify with flagEpisodesStorePath?
-	flagPodcastEpisodesPath string
 
 	// Tags
 	flagTagsWriteFile   bool


### PR DESCRIPTION
Remove duplicate flags flagNetlifyRedirectEpisodesPath and flagPodcastEpisodesPath that had the same meaning as flagEpisodesStorePath. Also remove the corresponding EnvVarNetlifyRedirectEpisodesDir environment variable constant. All podcast commands now use the unified flagEpisodesStorePath flag and EnvVarEpisodesStorePath env var.