### PR TITLE
Unify tags find flags with env var pattern used by other commands

### DIFF
--- a/website-admin/cmd/cmd_env.go
+++ b/website-admin/cmd/cmd_env.go
@@ -14,6 +14,8 @@ const (
 	EnvVarImagesPath                    = "WEBSITEADMIN_IMAGES_PATH"
 	EnvVarNetlifyRedirectTomlFile       = "WEBSITEADMIN_NETLIFY_REDIRECT_TOML_FILE"
 	EnvVarNetlifyRedirectRedirectPrefix = "WEBSITEADMIN_NETLIFY_REDIRECT_REDIRECT_PREFIX"
+	EnvVarTagsContentPath               = "WEBSITEADMIN_TAGS_CONTENT_PATH"
+	EnvVarTagsDescFile                  = "WEBSITEADMIN_TAGS_DESC_FILE"
 )
 
 var environmentVariables = map[string]string{
@@ -23,6 +25,8 @@ var environmentVariables = map[string]string{
 	EnvVarImagesPath:                    "Path to store podcast images",
 	EnvVarNetlifyRedirectTomlFile:       "Path to netlify.toml file for redirects",
 	EnvVarNetlifyRedirectRedirectPrefix: "Prefix for redirect URLs",
+	EnvVarTagsContentPath:               "Content directory to scan for tags",
+	EnvVarTagsDescFile:                  "Tag description file path",
 }
 
 var envCmd = &cobra.Command{
@@ -41,6 +45,8 @@ Checked environment variables:
   WEBSITEADMIN_IMAGES_PATH                Path to store podcast images
   WEBSITEADMIN_NETLIFY_REDIRECT_TOML_FILE Path to netlify.toml for redirects
   WEBSITEADMIN_NETLIFY_REDIRECT_REDIRECT_PREFIX  Prefix for redirect URLs
+  WEBSITEADMIN_TAGS_CONTENT_PATH          Content directory to scan for tags
+  WEBSITEADMIN_TAGS_DESC_FILE             Tag description file path
 
 Behavior:
   - Logs INFO for each environment variable that is set

--- a/website-admin/cmd/cmd_tags_find.go
+++ b/website-admin/cmd/cmd_tags_find.go
@@ -79,10 +79,9 @@ keys (e.g., "german_content.genres" for games).`,
 func init() {
 	tagsCmd.AddCommand(tagsFindCmd)
 
-	// TODO Add the flags as the same structure as other commands (env.go)
 	tagsFindCmd.Flags().BoolVarP(&flagTagsWriteFile, "write-file", "w", false, "Modify the local tag storage file and add missing tags")
-	tagsFindCmd.Flags().StringVarP(&flagTagsContentPath, "content-dir", "c", "", "Content directory to scan (overrides default for mode)")
-	tagsFindCmd.Flags().StringVarP(&flagTagsDescFile, "desc-file", "f", "", "Tag description file path (overrides default for mode)")
+	tagsFindCmd.Flags().StringVarP(&flagTagsContentPath, "content-dir", "c", os.Getenv(EnvVarTagsContentPath), environmentVariables[EnvVarTagsContentPath])
+	tagsFindCmd.Flags().StringVarP(&flagTagsDescFile, "desc-file", "f", os.Getenv(EnvVarTagsDescFile), environmentVariables[EnvVarTagsDescFile])
 }
 
 func RunTagsFindCmd(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Add WEBSITEADMIN_TAGS_CONTENT_PATH and WEBSITEADMIN_TAGS_DESC_FILE environment variables and update cmd_tags_find.go to use the same flag definition pattern as other commands (os.Getenv for default, environmentVariables map for description).