### PR TITLE
fix: correct broken blog post links in RSS feed

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -10,7 +10,7 @@ export async function GET(context) {
 		title: post.data.title,
 		pubDate: post.data.pubDate,
 		description: post.data.description,
-		link: `/posts/${post.id}/`,
+		link: `/blog/post/${post.id}/`,
 	}));
 
 	podcastEpisodes.map(function (episode) {


### PR DESCRIPTION
## Summary
- Blog post links in the RSS feed used `/posts/` prefix but the actual route is `/blog/post/`
- This caused all blog RSS links to return 404 for subscribers

## Test plan
- [ ] Build the site and inspect the generated RSS XML at `/rss.xml`
- [ ] Verify blog post links use the `/blog/post/` prefix
- [ ] Click a blog link from the RSS feed to confirm it resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)