### PR TITLE
fix: fix newsletter iframe sizing and accessibility

### DIFF
--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -36,7 +36,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 					<div class="flex flex-wrap justify-center -mx-4">
 						<script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
-						<iframe src="https://subscribe-forms.beehiiv.com/0250b21c-3fbe-4535-95f5-3afca8984d8a" class="beehiiv-embed" data-test-id="beehiiv-embed" frameborder="0" scrolling="no" style="width: ; height: ; margin: 0; border-radius: 0px 0px 0px 0px !important; background-color: transparent; box-shadow: 0 0 #0000;"></iframe>
+						<iframe src="https://subscribe-forms.beehiiv.com/0250b21c-3fbe-4535-95f5-3afca8984d8a" class="beehiiv-embed" data-test-id="beehiiv-embed" title="Engineering Kiosk Newsletter Anmeldung" scrolling="no" style="width: 100%; height: 220px; margin: 0; border: none; border-radius: 0; background-color: transparent;"></iframe>
 					</div>
 				</div>
 			</section>


### PR DESCRIPTION
## Summary
- Fixed empty `width` and `height` values in iframe style attribute (was `width: ; height: ;`)
- Added `title` attribute for screen reader accessibility
- Replaced deprecated `frameborder="0"` with CSS `border: none`

## Test plan
- [ ] Navigate to `/newsletter` and verify the Beehiiv embed renders correctly
- [ ] Check that the iframe has proper dimensions
- [ ] Run accessibility audit and verify no iframe title warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)