### PR TITLE
perf: add long-term cache headers for Astro static assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3484,6 +3484,11 @@
   force = true
 
 [[headers]]
+  for = "/_astro/*"
+  [headers.headers]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
   for = "/deutsche-tech-podcasts/podcasts.opml"
   [headers.headers]
     Content-Type = "text/x-opml"


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: public, max-age=31536000, immutable` for `/_astro/*` assets
- Astro generates content-hashed filenames, making these safe to cache indefinitely
- Reduces redundant network requests for returning visitors

## Test plan
- [ ] Deploy to preview and verify `curl -I <preview-url>/_astro/<any-file>` returns the cache header
- [ ] Verify site loads correctly with no broken assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)