### PR TITLE
cleanup: remove console.log statements from production components

### DIFF
--- a/src/components/PodcastEpisodeTranscript.astro
+++ b/src/components/PodcastEpisodeTranscript.astro
@@ -76,7 +76,6 @@ const { utterances, hideSpeakerInTranscript = false, pubDate } = Astro.props;
 	const trackEvent = function(eventType) {
 		const name = window.playerConfiguration.episode.title || 'unknown'										
 		_paq.push(['trackEvent', 'transcript', eventType, name]);
-		console.log('trackEvent', eventType, name);
 	}
 
 	window.showFullTranscript = function() {
@@ -120,7 +119,6 @@ const { utterances, hideSpeakerInTranscript = false, pubDate } = Astro.props;
 			utterances.forEach((utterance, i) => {
 				const start = parseInt(utterance.dataset.transStart);
 				if (start <= time && (!utterances[i+1] || utterances[i+1].dataset.transStart > time)) {
-					console.log('found', utterance, start, time);
 					element = utterance;
 				}
 			});

--- a/src/components/meetup/ImageSlider.astro
+++ b/src/components/meetup/ImageSlider.astro
@@ -69,15 +69,7 @@ const { images, autoSlideInterval = 5000, className = "relative rounded-7xl" } =
       const images = slider?.querySelectorAll('[data-index]') || [];
       const dots = sliderWrapper.querySelectorAll('button[data-index]');
 
-      console.log('Found slider:', {
-        wrapper: sliderWrapper,
-        slider: slider,
-        imagesCount: images.length,
-        dotsCount: dots.length
-      });
-
       if (!images.length || !dots.length || !slider) {
-        console.log('Skipping slider - missing elements');
         return;
       }
 
@@ -89,8 +81,6 @@ const { images, autoSlideInterval = 5000, className = "relative rounded-7xl" } =
 
       // Show specific slide
       function showSlide(index) {
-        console.log('Showing slide:', index, 'Total images:', images.length, 'Total dots:', dots.length);
-
         // Hide all images
         images.forEach((img, i) => {
           img.classList.add('opacity-0');
@@ -141,7 +131,6 @@ const { images, autoSlideInterval = 5000, className = "relative rounded-7xl" } =
       // Dot clicks
       dots.forEach((dot, index) => {
         dot.addEventListener('click', () => {
-          console.log('Dot clicked:', index);
           showSlide(index);
           stopAuto();
           startAuto();


### PR DESCRIPTION
## Summary
- Removes 6 `console.log` debug statements from production code
- `ImageSlider.astro`: removed 4 debug logs (slider found, skipping, showing slide, dot clicked)
- `PodcastEpisodeTranscript.astro`: removed 2 debug logs (trackEvent, found utterance)

## Test plan
- [ ] Verify image slider still works on meetup pages
- [ ] Verify transcript show/hide, sharing, and deep linking still work
- [ ] Open browser console — no debug logging on these pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)