### PR TITLE
fix: eliminate duplicate getCollection calls in dynamic routes

### DIFF
--- a/src/pages/deutsche-tech-podcasts/[tag]-podcasts.astro
+++ b/src/pages/deutsche-tech-podcasts/[tag]-podcasts.astro
@@ -13,8 +13,8 @@ import germanTechPodcastsTags from '../../data/german-tech-podcasts-tags.json';
 
 export async function getStaticPaths() {
 	// Get tags from the german tech podcasts
-	const germanTechPodcasts = await getCollection("germantechpodcasts");
-	const allPodcastTagsUniqueInclNull = [...new Set(germanTechPodcasts.flatMap((p) => p.data.tags))];
+	const allPodcasts = await getCollection("germantechpodcasts");
+	const allPodcastTagsUniqueInclNull = [...new Set(allPodcasts.flatMap((p) => p.data.tags))];
 	const allPodcastTagsUnique = allPodcastTagsUniqueInclNull.filter(function (tag) {
 		return tag != null;
 	});
@@ -30,12 +30,12 @@ export async function getStaticPaths() {
 
 		return {
 			params: { tag: tagUrlName },
-			props: { tagName },
+			props: { tagName, allPodcasts },
 		};
 	});
 }
 
-const tagHumanName = Astro.props.tagName;
+const { tagName: tagHumanName, allPodcasts } = Astro.props;
 
 let title = `${tagHumanName} Tech-Podcasts auf Deutsch - Engineering Kiosk`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -50,8 +50,7 @@ if (germanTechPodcastsTags.hasOwnProperty(tagHumanName)) {
 }
 
 // Filter german tech podcasts by tag, sort by name
-const germanTechPodcasts = await getCollection("germantechpodcasts");
-let podcasts = germanTechPodcasts.filter(function (p) {
+let podcasts = allPodcasts.filter(function (p) {
 	if (p.data.tags == null) {
 		return false;
 	}

--- a/src/pages/spiele-fuer-softwareentwickler/[genre]-spiele.astro
+++ b/src/pages/spiele-fuer-softwareentwickler/[genre]-spiele.astro
@@ -13,8 +13,8 @@ import awesomeSoftwareEngineeringGameGenres from '../../data/awesome-software-en
 
 export async function getStaticPaths() {
 	// Get genres from the "awesome-software-engineering-games" collection
-	const awesomeSoftwareEngineeringGames = await getCollection("awesome-software-engineering-games");
-	const allGameGenresUniqueInclNull = [...new Set(awesomeSoftwareEngineeringGames.flatMap((p) => p.data.german_content.genres))];
+	const allGames = await getCollection("awesome-software-engineering-games");
+	const allGameGenresUniqueInclNull = [...new Set(allGames.flatMap((p) => p.data.german_content.genres))];
 	const allGameGenresUnique = allGameGenresUniqueInclNull.filter(function (genre) {
 		return genre != null;
 	});
@@ -30,12 +30,12 @@ export async function getStaticPaths() {
 
 		return {
 			params: { genre: genreUrlName },
-			props: { genreName },
+			props: { genreName, allGames },
 		};
 	});
 }
 
-const genreHumanName = Astro.props.genreName;
+const { genreName: genreHumanName, allGames } = Astro.props;
 
 let title = `${genreHumanName} Spiele für Softwareentwickler:innen - Engineering Kiosk`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -49,9 +49,8 @@ if (awesomeSoftwareEngineeringGameGenres.hasOwnProperty(genreHumanName)) {
 	customTitle = awesomeSoftwareEngineeringGameGenres[genreHumanName]['title'] || '';
 }
 
-// Filter awesome software engineering games by genre, sort by name
-const awesomeSoftwareEngineeringGames = await getCollection("awesome-software-engineering-games");
-let games = awesomeSoftwareEngineeringGames.filter(function (p) {
+// Filter games by genre, sort by name
+let games = allGames.filter(function (p) {
 	if (p.data.german_content.genres == null) {
 		return false;
 	}


### PR DESCRIPTION
## Summary
- `[genre]-spiele.astro` and `[tag]-podcasts.astro` both called `getCollection()` twice — once in `getStaticPaths()` and once in the page body
- Now the collection data is passed via `props` from `getStaticPaths`, eliminating the redundant fetch
- This reduces build-time work for each generated page

## Test plan
- [ ] Build the site successfully (`make build`)
- [ ] Navigate to a genre page (e.g. `/spiele-fuer-softwareentwickler/strategie-spiele`)
- [ ] Navigate to a tag page (e.g. `/deutsche-tech-podcasts/devops-podcasts`)
- [ ] Verify all games/podcasts are still listed correctly with filters applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)