### PR TITLE
refactor: replace any and object types with proper TypeScript types

### DIFF
--- a/src/components/PodcastEpisodeTranscript.astro
+++ b/src/components/PodcastEpisodeTranscript.astro
@@ -1,10 +1,17 @@
 ---
 import PodcastEpisodeTranscriptLine from './PodcastEpisodeTranscriptLine.astro'	
 
+interface Utterance {
+	speaker: string;
+	start: number;
+	end: number;
+	text: string;
+}
+
 export interface Props {
-	utterances: object[]
-	hideSpeakerInTranscript?: boolean
-	pubDate?: Date
+	utterances: Utterance[];
+	hideSpeakerInTranscript?: boolean;
+	pubDate?: Date;
 }
 
 const { utterances, hideSpeakerInTranscript = false, pubDate } = Astro.props;

--- a/src/components/PodcastEpisodeTranscriptLine.astro
+++ b/src/components/PodcastEpisodeTranscriptLine.astro
@@ -1,6 +1,13 @@
 ---
+interface Utterance {
+	speaker: string;
+	start: number;
+	end: number;
+	text: string;
+}
+
 export interface Props {
-	utterance: object;
+	utterance: Utterance;
 	hideSpeakerName?: boolean;
 	pubDate?: Date;
 }

--- a/src/components/meetup/ImageSlider.astro
+++ b/src/components/meetup/ImageSlider.astro
@@ -1,9 +1,10 @@
 ---
 import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
 
 interface Props {
   images: {
-    src: any;
+    src: ImageMetadata;
     alt: string;
     title: string;
   }[];

--- a/src/components/meetup/MeetupArchiveLayout.astro
+++ b/src/components/meetup/MeetupArchiveLayout.astro
@@ -8,6 +8,7 @@ import Newsletter from './Newsletter.astro';
 import MeetupArchiveEvent from './MeetupArchiveEvent.astro';
 import Team from './Team.astro';
 import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
 
 import { createMeetupHelpers } from '../../scripts/meetups';
 
@@ -19,7 +20,7 @@ export interface Props {
 	ogImage: string;
 	badgeText: string;
 	archiveTitle: string;
-	heroImage: any;
+	heroImage: ImageMetadata;
 	heroImageAlt: string;
 	heroImageTitle: string;
 	teamBadge: string;

--- a/src/layouts/podcast-episode.astro
+++ b/src/layouts/podcast-episode.astro
@@ -32,7 +32,7 @@ let encoded_social_text = encodeURI(social_text);
 // Prepare speaker names for transcript
 // Our transcript only contains "Speaker A" and "Speaker B".
 // In the Podcast Episode Metadata, we also have real names :)
-const speakerMap = new Map();
+const speakerMap: Map<string, string> = new Map();
 frontmatter.speaker.forEach ((person, index) => {
 	if ('transcriptLetter' in person) {
 		speakerMap.set(person.transcriptLetter, person.name);


### PR DESCRIPTION
## Summary
- Replaces `any` types with `ImageMetadata` from `astro` in `ImageSlider` and `MeetupArchiveLayout` props
- Types `speakerMap` as `Map<string, string>` in podcast-episode layout
- Defines `Utterance` interface and replaces `object[]`/`object` types in transcript components

## Test plan
- [ ] Build the site (`make build`) — type errors will surface at build time
- [ ] Verify podcast episode pages with transcripts render correctly
- [ ] Verify meetup archive pages render correctly
- [ ] Verify meetup pages with image sliders render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)