### PR TITLE
refactor: upgrade to Astro strict TypeScript preset

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "astro/tsconfigs/base",
+  "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "strictNullChecks": true,
     "allowJs": true
   }
 }


### PR DESCRIPTION
## Summary
- Switches from `astro/tsconfigs/base` + manual `strictNullChecks` to `astro/tsconfigs/strict`
- The strict preset enables full TypeScript strict mode: `noImplicitAny`, `noImplicitThis`, `alwaysStrict`, `strictBindCallApply`, `strictFunctionTypes`, `strictPropertyInitialization`, and `strictNullChecks`
- This catches more type errors at build time

## Test plan
- [ ] Run `make build` — any new type errors will surface here
- [ ] If type errors occur, they indicate existing issues that were previously hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)