### PR TITLE
test: add vitest and unit tests for JavaScript utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "esbuild": "0.28.0",
         "postcss-nesting": "14.0.0",
         "prettier": "3.8.2",
-        "prettier-plugin-astro": "0.14.1"
+        "prettier-plugin-astro": "0.14.1",
+        "vitest": "^4.1.4"
       },
       "engines": {
         "node": ">=24"
@@ -238,7 +239,6 @@
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -260,7 +260,6 @@
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1287,7 +1286,6 @@
       "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
@@ -1312,7 +1310,6 @@
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1643,7 +1640,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1660,7 +1656,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1677,7 +1672,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1694,7 +1688,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1711,7 +1704,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1731,7 +1723,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1751,7 +1742,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1771,7 +1761,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1791,7 +1780,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1811,7 +1799,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1831,7 +1818,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1848,7 +1834,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1862,7 +1847,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -1884,7 +1868,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1901,7 +1884,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1911,8 +1893,7 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2406,6 +2387,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2772,9 +2760,19 @@
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/debug": {
@@ -2785,6 +2783,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2870,6 +2875,119 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2945,6 +3063,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3300,6 +3428,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -3416,6 +3554,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -4335,6 +4480,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6586,6 +6741,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -7150,7 +7312,6 @@
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
         "@rolldown/pluginutils": "1.0.0-rc.15"
@@ -7345,6 +7506,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7419,6 +7587,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -7531,6 +7713,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -7563,6 +7752,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -8010,7 +8209,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8102,6 +8300,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8119,6 +8407,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.2.2",
     "esbuild": "0.28.0",
     "postcss-nesting": "14.0.0",
     "prettier": "3.8.2",
-    "prettier-plugin-astro": "0.14.1"
+    "prettier-plugin-astro": "0.14.1",
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.0",

--- a/src/scripts/date.test.js
+++ b/src/scripts/date.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+	millisecondsToHumanTimestamp,
+	humanTimestampToSecondsTo,
+	monthSuffixedDay,
+	formatDateWithWeekdayAndOrdinal,
+	year,
+} from './date.js';
+
+describe('millisecondsToHumanTimestamp', () => {
+	it.each([
+		[0, '00:00:00'],
+		[1000, '00:00:01'],
+		[60000, '00:01:00'],
+		[3600000, '01:00:00'],
+		[3661000, '01:01:01'],
+		[500, '00:00:00'], // sub-second rounds down
+		[86399000, '23:59:59'], // just under 24 hours
+		[5430000, '01:30:30'],
+	])('millisecondsToHumanTimestamp(%i) = %s', (ms, expected) => {
+		expect(millisecondsToHumanTimestamp(ms)).toBe(expected);
+	});
+});
+
+describe('humanTimestampToSecondsTo', () => {
+	it.each([
+		['00:00:00', 0],
+		['01:30:45', 5445],
+		['00:05:30', 330],
+		['(01:30:45)', 5445], // parentheses stripped
+		['(00:05:30)', 330],
+		['00:00:01', 1],
+		['23:59:59', 86399],
+	])('humanTimestampToSecondsTo(%s) = %i', (ts, expected) => {
+		expect(humanTimestampToSecondsTo(ts)).toBe(expected);
+	});
+});
+
+describe('monthSuffixedDay', () => {
+	it.each([
+		// 1st, 2nd, 3rd
+		['2026-01-01', 'en-US', 'January 1st'],
+		['2026-01-02', 'en-US', 'January 2nd'],
+		['2026-01-03', 'en-US', 'January 3rd'],
+		// 4th through 20th all get "th"
+		['2026-01-04', 'en-US', 'January 4th'],
+		['2026-01-11', 'en-US', 'January 11th'],
+		['2026-01-12', 'en-US', 'January 12th'],
+		['2026-01-13', 'en-US', 'January 13th'],
+		// 21st, 22nd, 23rd
+		['2026-01-21', 'en-US', 'January 21st'],
+		['2026-01-22', 'en-US', 'January 22nd'],
+		['2026-01-23', 'en-US', 'January 23rd'],
+		['2026-01-30', 'en-US', 'January 30th'],
+	])('monthSuffixedDay(%s, %s) = %s', (date, locale, expected) => {
+		expect(monthSuffixedDay(date, locale)).toBe(expected);
+	});
+});
+
+describe('formatDateWithWeekdayAndOrdinal', () => {
+	it('formats a date with weekday and ordinal suffix', () => {
+		// 2026-02-26 is a Thursday
+		expect(formatDateWithWeekdayAndOrdinal('2026-02-26', 'en-US')).toBe(
+			'Thursday, 26th of February 2026'
+		);
+	});
+
+	it('handles 1st suffix', () => {
+		// 2026-03-01 is a Sunday
+		expect(formatDateWithWeekdayAndOrdinal('2026-03-01', 'en-US')).toBe(
+			'Sunday, 1st of March 2026'
+		);
+	});
+
+	it('handles 2nd suffix', () => {
+		// 2026-03-02 is a Monday
+		expect(formatDateWithWeekdayAndOrdinal('2026-03-02', 'en-US')).toBe(
+			'Monday, 2nd of March 2026'
+		);
+	});
+
+	it('handles 3rd suffix', () => {
+		// 2026-03-03 is a Tuesday
+		expect(formatDateWithWeekdayAndOrdinal('2026-03-03', 'en-US')).toBe(
+			'Tuesday, 3rd of March 2026'
+		);
+	});
+
+	it('handles 11th (not 11st)', () => {
+		// 2026-03-11 is a Wednesday
+		expect(formatDateWithWeekdayAndOrdinal('2026-03-11', 'en-US')).toBe(
+			'Wednesday, 11th of March 2026'
+		);
+	});
+});
+
+describe('year', () => {
+	it('extracts year from date string', () => {
+		expect(year('2026-04-10', 'en-US')).toBe('2026');
+	});
+
+	it('extracts year from Date object', () => {
+		expect(year(new Date(2025, 0, 1), 'en-US')).toBe('2025');
+	});
+});

--- a/src/scripts/sorting.test.js
+++ b/src/scripts/sorting.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { orderByName, sortByDateDesc } from './sorting.js';
+
+describe('orderByName', () => {
+	it('sorts items by data.name case-insensitively', () => {
+		const items = [
+			{ data: { name: 'Zebra' } },
+			{ data: { name: 'apple' } },
+			{ data: { name: 'Banana' } },
+		];
+		const sorted = [...items].sort(orderByName);
+		expect(sorted.map((i) => i.data.name)).toEqual(['apple', 'Banana', 'Zebra']);
+	});
+
+	it('returns 0 for equal names', () => {
+		const a = { data: { name: 'test' } };
+		const b = { data: { name: 'Test' } };
+		expect(orderByName(a, b)).toBe(0);
+	});
+});
+
+describe('sortByDateDesc', () => {
+	it('sorts items by pubDate descending', () => {
+		const items = [
+			{ data: { pubDate: '2024-01-01' } },
+			{ data: { pubDate: '2024-06-15' } },
+			{ data: { pubDate: '2024-03-10' } },
+		];
+		sortByDateDesc(items);
+		expect(items.map((i) => i.data.pubDate)).toEqual(['2024-06-15', '2024-03-10', '2024-01-01']);
+	});
+
+	it('supports custom date field name', () => {
+		const items = [
+			{ data: { date: '2024-01-01' } },
+			{ data: { date: '2024-12-25' } },
+		];
+		sortByDateDesc(items, 'date');
+		expect(items.map((i) => i.data.date)).toEqual(['2024-12-25', '2024-01-01']);
+	});
+
+	it('handles empty array', () => {
+		const items = [];
+		sortByDateDesc(items);
+		expect(items).toEqual([]);
+	});
+});

--- a/src/scripts/strings.test.js
+++ b/src/scripts/strings.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { cutText, cleanDescription } from './strings.js';
+
+describe('cutText', () => {
+	it('returns text unchanged if shorter than limit', () => {
+		expect(cutText('Hello', 10)).toBe('Hello');
+	});
+
+	it('cuts at last space before limit and adds ellipsis', () => {
+		expect(cutText('Hello World Foo Bar', 11)).toBe('Hello World...');
+	});
+
+	it('returns full text if no space found before limit', () => {
+		expect(cutText('Superlongwordwithoutspaces', 10)).toBe('Superlongwordwithoutspaces');
+	});
+
+	it('returns text unchanged if exactly at limit', () => {
+		expect(cutText('Hello', 5)).toBe('Hello');
+	});
+
+	it('handles empty string', () => {
+		expect(cutText('', 10)).toBe('');
+	});
+
+	it('cuts at word boundary for longer text', () => {
+		const text = 'This is a longer sentence that should be cut at a word boundary';
+		const result = cutText(text, 30);
+		expect(result).toBe('This is a longer sentence that...');
+		expect(result.length).toBeLessThanOrEqual(33); // 30 + '...'
+	});
+});
+
+describe('cleanDescription', () => {
+	it('removes text from marker onwards', () => {
+		expect(cleanDescription('Good content. Unsere aktuellen Werbepartner: Sponsor1')).toBe(
+			'Good content.'
+		);
+	});
+
+	it('returns unchanged if no marker present', () => {
+		expect(cleanDescription('Just a normal description')).toBe('Just a normal description');
+	});
+
+	it('trims whitespace before marker', () => {
+		expect(cleanDescription('Content   Unsere aktuellen Werbepartner')).toBe('Content');
+	});
+
+	it('handles marker at the very start', () => {
+		expect(cleanDescription('Unsere aktuellen Werbepartner and more')).toBe('');
+	});
+});

--- a/src/scripts/urlify.test.js
+++ b/src/scripts/urlify.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { URLify } from './urlify.js';
+
+describe('URLify', () => {
+	it('converts spaces to hyphens', () => {
+		expect(URLify('Hello World')).toEqual({ name: 'Hello World', url: 'hello-world' });
+	});
+
+	it('removes dots', () => {
+		expect(URLify('Node.js')).toEqual({ name: 'Node.js', url: 'nodejs' });
+	});
+
+	it('lowercases the url', () => {
+		expect(URLify('TypeScript')).toEqual({ name: 'TypeScript', url: 'typescript' });
+	});
+
+	it('preserves original name', () => {
+		const result = URLify('Infrastructure as Code');
+		expect(result.name).toBe('Infrastructure as Code');
+		expect(result.url).toBe('infrastructure-as-code');
+	});
+
+	it('trims whitespace', () => {
+		expect(URLify('  padded  ')).toEqual({ name: '  padded  ', url: 'padded' });
+	});
+
+	it('handles multiple spaces', () => {
+		const result = URLify('a b');
+		expect(result.url).toBe('a-b');
+	});
+
+	it('handles combined dots and spaces', () => {
+		expect(URLify('C.I. / C.D.')).toEqual({ name: 'C.I. / C.D.', url: 'ci-/-cd' });
+	});
+});


### PR DESCRIPTION
## Summary
- Installs `vitest` as dev dependency and adds `test` script to package.json
- Adds 55 unit tests across 4 utility modules:
  - `date.js` (33 tests): timestamp conversion, ordinal suffixes (1st/2nd/3rd/11th/12th/13th), year extraction
  - `strings.js` (10 tests): word-boundary text cutting, German ad marker removal
  - `urlify.js` (7 tests): space→hyphen, dot removal, case conversion, trimming
  - `sorting.js` (5 tests): case-insensitive name sorting, date descending sort

## Test plan
- [x] `npx vitest run` — all 55 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)