### PR TITLE
ci: add GitHub Actions workflow for JavaScript unit tests via vitest

### DIFF
--- a/.github/workflows/javascript-testing.yml
+++ b/.github/workflows/javascript-testing.yml
@@ -1,0 +1,37 @@
+name: JavaScript testing
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**/*.js'
+      - 'src/**/*.ts'
+      - 'src/**/*.astro'
+      - 'package.json'
+      - 'package-lock.json'
+  pull_request:
+    paths:
+      - 'src/**/*.js'
+      - 'src/**/*.ts'
+      - 'src/**/*.astro'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+jobs:
+  testing:
+    name: Testing (JavaScript)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.14.1
+
+      - name: Install dependencies
+        run: make init-javascript
+
+      - name: Run unit tests
+        run: make test-javascript

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ init: init-javascript ## Installs all dependencies (JavaScript)
 init-javascript: ## Installs JavaScript dependencies
 	npm install
 
+.PHONY: test-javascript
+test-javascript: ## Runs JavaScript unit tests via vitest
+	npm test
+
 .PHONY: prettier
 prettier: ## Run code formatter prettier (for JavaScript)
 	node_modules/.bin/prettier -w .


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/javascript-testing.yml` runs `vitest` unit tests
- New Makefile target `test-javascript` for local use (`make test-javascript`)
- Only triggers when relevant files change:
  - `src/**/*.js`, `src/**/*.ts`, `src/**/*.astro`
  - `package.json`, `package-lock.json`

## Design decisions
- Modeled after `go-testing.yml`: same structure (push to main + PRs + workflow_dispatch), pinned actions
- Uses the same Node.js version (`24.14.1`) and action pins as `astro-testing.yml` for consistency
- Path filtering avoids running JS tests on Go-only or content-only changes

## Context
Follow-up to #1387 which added vitest and 55 unit tests for JavaScript utilities.

## Test plan
- [x] `npm test` — all 55 tests pass locally
- [x] `make test-javascript` — works locally
- [ ] Workflow should trigger on this PR (since it modifies a workflow file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)