### PR TITLE
Fix meetup pages crashing when no upcoming event is scheduled

### DIFF
--- a/src/components/meetup/MeetupPageLayout.astro
+++ b/src/components/meetup/MeetupPageLayout.astro
@@ -59,12 +59,14 @@ const { getNextMeetup } = await createMeetupHelpers(collectionName);
 
 const bufferDays = 1;
 const nextMeetup = getNextMeetup(bufferDays);
-const dateString = formatDateWithoutWeekday(nextMeetup.date, 'en-US');
-const timeString = formatTime(nextMeetup.date);
-const dateAndTime = `${dateString} - open doors at ${timeString} (talks start ~30min later)`;
-const registrationClosed = nextMeetup.registrationClosed || false;
+const dateString = nextMeetup ? formatDateWithoutWeekday(nextMeetup.date, 'en-US') : null;
+const timeString = nextMeetup ? formatTime(nextMeetup.date) : null;
+const dateAndTime = nextMeetup ? `${dateString} - open doors at ${timeString} (talks start ~30min later)` : null;
+const registrationClosed = nextMeetup ? (nextMeetup.registrationClosed || false) : false;
 
-const description = `In-person tech meetup in ${meetupName} (Next: ${dateString}): A local community event for software engineers, developers and tech enthusiasts featuring talks on engineering culture, open source and technology.`;
+const description = nextMeetup
+	? `In-person tech meetup in ${meetupName} (Next: ${dateString}): A local community event for software engineers, developers and tech enthusiasts featuring talks on engineering culture, open source and technology.`
+	: `In-person tech meetup in ${meetupName}: A local community event for software engineers, developers and tech enthusiasts featuring talks on engineering culture, open source and technology.`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 ---
@@ -92,29 +94,43 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 								<p class="mb-8 text-lg md:text-xl text-coolGray-500 font-medium">
 									{heroDescription}
 								</p>
-								<h2 class="text-lg md:text-2xl text-coolGray-500 font-medium">Next Meetup @ <div class="h-10 inline-block"><CompanyLogo name={nextMeetup.location.name} logo={nextMeetup.location.logo} url={nextMeetup.location.url} logoHeight="40" /></div></h2>
-								<p class="mt-2 text-sm md:text-base text-coolGray-500 font-medium">
-									📅 Date <span class="font-bold">{dateAndTime}</span>
-								</p>
-								<div class="mb-8 text-sm md:text-base text-coolGray-500 font-medium">
-									📍 Location:
-									{
-										nextMeetup.location.url && (
-											<a href={nextMeetup.location.url} target="_blank" rel="noopener noreferrer">
-												{nextMeetup.location.name}
-											</a>
-										)
-									}
-									{!nextMeetup.location.url && nextMeetup.location.name} (<a href={`http://maps.google.com/?q=${encodeURIComponent(nextMeetup.location.address)}`} target="_blank" class="underline">{nextMeetup.location.address}</a>
-									{nextMeetup.location.note && (
-										<span class="text-xs">{nextMeetup.location.note}</span>
-									)})
+								{nextMeetup ? (
+									<>
+										<h2 class="text-lg md:text-2xl text-coolGray-500 font-medium">Next Meetup @ <div class="h-10 inline-block"><CompanyLogo name={nextMeetup.location.name} logo={nextMeetup.location.logo} url={nextMeetup.location.url} logoHeight="40" /></div></h2>
+										<p class="mt-2 text-sm md:text-base text-coolGray-500 font-medium">
+											📅 Date <span class="font-bold">{dateAndTime}</span>
+										</p>
+										<div class="mb-8 text-sm md:text-base text-coolGray-500 font-medium">
+											📍 Location:
+											{
+												nextMeetup.location.url && (
+													<a href={nextMeetup.location.url} target="_blank" rel="noopener noreferrer">
+														{nextMeetup.location.name}
+													</a>
+												)
+											}
+											{!nextMeetup.location.url && nextMeetup.location.name} (<a href={`http://maps.google.com/?q=${encodeURIComponent(nextMeetup.location.address)}`} target="_blank" class="underline">{nextMeetup.location.address}</a>
+											{nextMeetup.location.note && (
+												<span class="text-xs">{nextMeetup.location.note}</span>
+											)})
 
-								</div>
+										</div>
+									</>
+								) : (
+									<>
+										<h2 class="text-lg md:text-2xl text-coolGray-500 font-medium">Next Meetup: To be announced</h2>
+										<p class="mt-2 mb-8 text-sm md:text-base text-coolGray-500 font-medium">
+											We are working on the next meetup. <a class="text-yellow-500 underline" data-scroll-to="a[name=newsletter]" href="#newsletter">Subscribe</a> to get notified as soon as the date is set.
+										</p>
+									</>
+								)}
 
 								<div class="flex flex-wrap mt-2">
 									<div class="w-full md:w-auto py-1 md:py-0 md:mr-4">
 									{ () => {
+										if (!nextMeetup) {
+											return null;
+										}
 										if (!registrationClosed) {
 											return(
 												<a
@@ -164,9 +180,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 				</div>
 			</section>
 
-			<MeetupListing meetupsToShow={[nextMeetup]} headline='Awesome Community Talks' meetupName={meetupName} meetupSlug={meetupSlug} meetupImage={ogImage} showGeneralLanguageNote={showGeneralLanguageNote} />
+			<MeetupListing meetupsToShow={nextMeetup ? [nextMeetup] : []} headline='Awesome Community Talks' meetupName={meetupName} meetupSlug={meetupSlug} meetupImage={ogImage} showGeneralLanguageNote={showGeneralLanguageNote} />
 
 			{ () => {
+				if (!nextMeetup) {
+					return null;
+				}
 				if (showRegistrationForm && !registrationClosed) {
 					return(
 					<section class="py-4 md:py-24 bg-white" style="background-image: url('/images/elements/pattern-white.svg'); background-position: center;">

--- a/src/components/meetup/PromoteAnnounceNewsletter.astro
+++ b/src/components/meetup/PromoteAnnounceNewsletter.astro
@@ -1,7 +1,7 @@
 ---
 import MainHead from '../MainHead.astro';
 
-import { formatDate, formatDateWithoutWeekday, formatTime, monthSuffixedDay, year} from '../../scripts/date.js';
+import { monthSuffixedDay, year} from '../../scripts/date.js';
 import { createMeetupHelpers } from '../../scripts/meetups.js';
 
 export interface Props {
@@ -23,12 +23,10 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 // Current Meetup
 const bufferDays = 1;
 const nextMeetup = getNextMeetup(bufferDays);
-const dateString = formatDate(nextMeetup.date, 'en-US');
-const dateStringMonthDay = monthSuffixedDay(nextMeetup.date);
-const dateStringYear = year(nextMeetup.date);
-const hostName = nextMeetup.hostName
-const locationName = nextMeetup.location.name
-const locationAddress = nextMeetup.location.address
+const dateStringMonthDay = nextMeetup ? monthSuffixedDay(nextMeetup.date) : null;
+const dateStringYear = nextMeetup ? year(nextMeetup.date) : null;
+const locationName = nextMeetup?.location.name;
+const locationAddress = nextMeetup?.location.address;
 ---
 
 <html lang="de">
@@ -39,25 +37,29 @@ const locationAddress = nextMeetup.location.address
 
 	<body class="antialiased bg-body text-body">
 
-		<h1 class="text-xl font-bold">Engineering Kiosk Meetup Announcement - {dateStringMonthDay}</h1>
+		<h1 class="text-xl font-bold">Engineering Kiosk Meetup Announcement{nextMeetup ? ` - ${dateStringMonthDay}` : ''}</h1>
 
-		<p>
-				<br/>
-				We would like to invite you to the next <b>Engineering Kiosk Meetup</b>, this time we will meet at the following date & location: <br/>
-		<br/>
-			&#128197; {dateStringMonthDay}, {dateStringYear}<br/>
-		&#x1F389;  Hosted by: {locationName}<br/>
-		&#128205;  Location: {locationAddress}<br/>
-		<br/>
-		<b>&#x1F3A4; Featured Talks</b><br/>
-		<br/>
-		{nextMeetup.talks.map((talk, j) => (
-				<span><b>{talk.title} by {talk.name}:</b> {talk.description}</span><br/><br/>
-		))}
-		&#128221; Reserve Your Spot and receive an instant calendar invite: <a href={`https://engineeringkiosk.dev/${meetupUrl}`}>https://engineeringkiosk.dev/{meetupUrl}</a><br/>
-		<br/>
-		cheers,<br/>
-		{teamSignoff}<br/>
-		</p>
+		{nextMeetup ? (
+			<p>
+					<br/>
+					We would like to invite you to the next <b>Engineering Kiosk Meetup</b>, this time we will meet at the following date & location: <br/>
+			<br/>
+				&#128197; {dateStringMonthDay}, {dateStringYear}<br/>
+			&#x1F389;  Hosted by: {locationName}<br/>
+			&#128205;  Location: {locationAddress}<br/>
+			<br/>
+			<b>&#x1F3A4; Featured Talks</b><br/>
+			<br/>
+			{nextMeetup.talks.map((talk) => (
+					<span><b>{talk.title} by {talk.name}:</b> {talk.description}</span><br/><br/>
+			))}
+			&#128221; Reserve Your Spot and receive an instant calendar invite: <a href={`https://engineeringkiosk.dev/${meetupUrl}`}>https://engineeringkiosk.dev/{meetupUrl}</a><br/>
+			<br/>
+			cheers,<br/>
+			{teamSignoff}<br/>
+			</p>
+		) : (
+			<p>No upcoming meetup is scheduled yet.</p>
+		)}
 	</body>
 </html>

--- a/src/components/meetup/PromoteNewsletter.astro
+++ b/src/components/meetup/PromoteNewsletter.astro
@@ -1,7 +1,7 @@
 ---
 import MainHead from '../MainHead.astro';
 
-import { formatDate, formatDateWithoutWeekday, formatTime, monthSuffixedDay, year} from '../../scripts/date.js';
+import { formatTime, monthSuffixedDay, year} from '../../scripts/date.js';
 import { createMeetupHelpers } from '../../scripts/meetups.js';
 
 export interface Props {
@@ -23,37 +23,39 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 // Current Meetup
 const bufferDays = 1;
 const nextMeetup = getNextMeetup(bufferDays);
-const dateString = formatDate(nextMeetup.date, 'en-US');
-const dateStringMonthDay = monthSuffixedDay(nextMeetup.date);
-const dateStringYear = year(nextMeetup.date);
-const timeString = formatTime(nextMeetup.date);
-const hostName = nextMeetup.hostName
-const locationName = nextMeetup.location.name
-const locationAddress = nextMeetup.location.address
+const dateStringMonthDay = nextMeetup ? monthSuffixedDay(nextMeetup.date) : null;
+const dateStringYear = nextMeetup ? year(nextMeetup.date) : null;
+const timeString = nextMeetup ? formatTime(nextMeetup.date) : null;
+const locationName = nextMeetup?.location.name;
+const locationAddress = nextMeetup?.location.address;
 ---
 
 <html lang="de">
 	<body class="antialiased bg-body text-body">
 
-		<h1 class="text-xl font-bold">Engineering Kiosk Meetup Announcement - {dateStringMonthDay}</h1>
+		<h1 class="text-xl font-bold">Engineering Kiosk Meetup Announcement{nextMeetup ? ` - ${dateStringMonthDay}` : ''}</h1>
 
-		<p>
-				<br/>
-				We would like to invite you to the next <b>Engineering Kiosk Meetup</b>, this time we will meet at the following date & location: <br/>
-		<br/>
-			&#128197; {dateStringMonthDay}, {dateStringYear} - {timeString}<br/>
-		&#128591; Hosted by: {locationName}<br/>
-		&#128205; Location: {locationAddress}<br/>
-		<br/>
-		&#x1F3A4; Featured Talks<br/>
-		<br/>
-		{nextMeetup.talks.map((talk, j) => (
-				<span><b>{talk.title} by {talk.name}:</b> {talk.description}</span><br/><br/>
-		))}
-		&#128221; Reserve Your Spot and receive an instant calendar invite: <a href={`https://engineeringkiosk.dev/${meetupUrl}`}>https://engineeringkiosk.dev/{meetupUrl}</a><br/>
-		<br/>
-		cheers,<br/>
-		{teamSignoff}<br/>
-		</p>
+		{nextMeetup ? (
+			<p>
+					<br/>
+					We would like to invite you to the next <b>Engineering Kiosk Meetup</b>, this time we will meet at the following date & location: <br/>
+			<br/>
+				&#128197; {dateStringMonthDay}, {dateStringYear} - {timeString}<br/>
+			&#128591; Hosted by: {locationName}<br/>
+			&#128205; Location: {locationAddress}<br/>
+			<br/>
+			&#x1F3A4; Featured Talks<br/>
+			<br/>
+			{nextMeetup.talks.map((talk) => (
+					<span><b>{talk.title} by {talk.name}:</b> {talk.description}</span><br/><br/>
+			))}
+			&#128221; Reserve Your Spot and receive an instant calendar invite: <a href={`https://engineeringkiosk.dev/${meetupUrl}`}>https://engineeringkiosk.dev/{meetupUrl}</a><br/>
+			<br/>
+			cheers,<br/>
+			{teamSignoff}<br/>
+			</p>
+		) : (
+			<p>No upcoming meetup is scheduled yet.</p>
+		)}
 	</body>
 </html>

--- a/src/components/meetup/PromoteSocialImage.astro
+++ b/src/components/meetup/PromoteSocialImage.astro
@@ -23,7 +23,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 // Current Meetup
 const bufferDays = 1;
 const nextMeetup = getNextMeetup(bufferDays);
-const dateString = formatDate(nextMeetup.date, 'en-US');
+const dateString = nextMeetup ? formatDate(nextMeetup.date, 'en-US') : null;
 
 const defaultAvatarPath = `/meetup/${meetupUrl}/images/speaker/avatar.png`;
 
@@ -37,26 +37,32 @@ const defaultAvatarPath = `/meetup/${meetupUrl}/images/speaker/avatar.png`;
 	<body class="antialiased bg-body text-body font-body">
 		<section style={`background-image: url('${ogImage}'); width: 700px; height: 700px;`} class="block text-center flex flex-col font-medium">
 			<h1 class="text-white text-5xl font-semibold p-3">Engineering Kiosk {meetupName}</h1>
-		  <h2 class="text-white text-4xl">{dateString}</h2>
-			<h2 class="text-white text-4xl">Meetup in {meetupCity}</h2>
-			<div class="text-2xl p-4">engineeringkiosk.dev/{meetupUrl}</div>
-			<div class="bg-white bg-opacity-90 mt-auto p-4 relative">
-				<div class="text-2xl">
-					hosted by {nextMeetup.location.logo ? <Image class="h-12 inline" src={nextMeetup.location.logo} alt={nextMeetup.location.name} /> : nextMeetup.location.name}
-				</div>
-			{nextMeetup.talks.map((talk, j) => (
-				<div class="flex flex-row my-2 mx-4">
-					{(() => {
-						const avatarArray = talk.avatar ? (Array.isArray(talk.avatar) ? talk.avatar : [talk.avatar]) : [];
-						return avatarArray.length
-							? avatarArray.map((av) => <Image class="w-32 h-32 rounded-full" src={av} alt={talk.name} />)
-							: <img class="w-32 h-32 rounded-full" src={defaultAvatarPath} alt={talk.name} />;
-					})()}
-					<h3 class="ml-4 text-2xl text-left my-auto">{talk.title}<br>by <span class="text-yellow-500">{talk.name}</span></h3>
-				</div>
-			))}
-				<img src={`/images/logos/engineering-kiosk-logo.svg`} alt="Engineering Kiosk" class="h-20 inline absolute bottom-4 right-4" />
-			</div>
+			{nextMeetup ? (
+				<>
+					<h2 class="text-white text-4xl">{dateString}</h2>
+					<h2 class="text-white text-4xl">Meetup in {meetupCity}</h2>
+					<div class="text-2xl p-4">engineeringkiosk.dev/{meetupUrl}</div>
+					<div class="bg-white bg-opacity-90 mt-auto p-4 relative">
+						<div class="text-2xl">
+							hosted by {nextMeetup.location.logo ? <Image class="h-12 inline" src={nextMeetup.location.logo} alt={nextMeetup.location.name} /> : nextMeetup.location.name}
+						</div>
+					{nextMeetup.talks.map((talk) => (
+						<div class="flex flex-row my-2 mx-4">
+							{(() => {
+								const avatarArray = talk.avatar ? (Array.isArray(talk.avatar) ? talk.avatar : [talk.avatar]) : [];
+								return avatarArray.length
+									? avatarArray.map((av) => <Image class="w-32 h-32 rounded-full" src={av} alt={talk.name} />)
+									: <img class="w-32 h-32 rounded-full" src={defaultAvatarPath} alt={talk.name} />;
+							})()}
+							<h3 class="ml-4 text-2xl text-left my-auto">{talk.title}<br>by <span class="text-yellow-500">{talk.name}</span></h3>
+						</div>
+					))}
+						<img src={`/images/logos/engineering-kiosk-logo.svg`} alt="Engineering Kiosk" class="h-20 inline absolute bottom-4 right-4" />
+					</div>
+				</>
+			) : (
+				<h2 class="text-white text-4xl">No upcoming meetup is scheduled yet.</h2>
+			)}
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- `make build` was failing with `TypeError: Cannot read properties of undefined (reading 'date')` while prerendering `/meetup/rhine-ruhr/promote/announce-newsletter/`. Root cause: the Rhine Ruhr collection no longer has a future-dated meetup, so `getNextMeetup(bufferDays)` returns `undefined`, and several components dereferenced it unconditionally.
- Guard `nextMeetup` in `PromoteAnnounceNewsletter.astro`, `PromoteNewsletter.astro`, `PromoteSocialImage.astro`, and `MeetupPageLayout.astro` so the affected pages render a "To be announced" / "No upcoming meetup is scheduled yet." fallback between meetups instead of crashing the build. `MeetupListing` is now passed `[]` instead of `[undefined]`, and the registration form is skipped when there is nothing to register for.
- Drive-by cleanup in `PromoteAnnounceNewsletter.astro`: removed the unused `formatDateWithoutWeekday` / `formatTime` imports, the unused `dateString` and `hostName` locals, and the unused `j` parameter in the talks `.map(...)`. Same dead `formatDate` / `formatDateWithoutWeekday` imports removed from `PromoteNewsletter.astro`.

## Test plan

- [x] `make build` completes cleanly (463 pages built) on a state where Rhine Ruhr has no future meetup.
- [x] Generated `dist/meetup/rhine-ruhr/index.html`, `.../promote/announce-newsletter/index.html`, and `.../promote/newsletter/index.html` contain the fallback copy and zero literal `undefined` strings.
- [x] Generated `dist/meetup/alps/promote/announce-newsletter/index.html` (Alps still has a future meetup) renders the full announcement with date, location, and talks, identical to before.
- [ ] After merge, watch the next CI build for the daily RSS sync to confirm it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)