### PR TITLE
Display open-source license on game previews

### DIFF
--- a/src/components/SoftwareEngineeringGamePreview.astro
+++ b/src/components/SoftwareEngineeringGamePreview.astro
@@ -53,6 +53,22 @@ const nameId = URLify(game.data.name);
 						{game.data.platforms.mac && (<img class="h-7 inline" src="/images/brands/apple-os.svg" alt={`${game.data.name} auf Mac`} title={`${game.data.name} auf Mac`} />)}
 						{game.data.platforms.linux && (<img class="h-7 inline" src="/images/brands/linux.svg" alt={`${game.data.name} auf Linux`} title={`${game.data.name} auf Linux`} />)}
 					</li>
+					{
+						game.data.license && (
+							<li class="pt-2">
+								Lizenz:{' '}
+								<a
+									class="hover:underline hover:text-yellow-500"
+									href={game.data.license.url}
+									title={`Lizenz von ${game.data.name}: ${game.data.license.name}`}
+									rel="license noopener"
+									target="_blank"
+								>
+									{game.data.license.spdx_id}
+								</a>
+							</li>
+						)
+					}
 				</ul>
 				
 				<div class="flex flex-wrap">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -173,6 +173,13 @@ const awesomeSoftwareEngineeringGamesCollection = defineCollection({
 				categories: z.array(z.string()).optional(),
 				genres: z.array(z.string()),
 			}),
+			license: z
+				.object({
+					name: z.string(),
+					spdx_id: z.string(),
+					url: z.string().url(),
+				})
+				.optional(),
 		}),
 });
 


### PR DESCRIPTION
## Summary

- Extend the `awesome-software-engineering-games` content schema with an optional `license` object (`name`, `spdx_id`, `url`) so Astro surfaces the field added upstream in [awesome-software-engineering-games#49](https://github.com/EngineeringKiosk/awesome-software-engineering-games/pull/49).
- Render a new "Lizenz: \<SPDX\>" bullet in `SoftwareEngineeringGamePreview.astro` that links to the license file, conditionally — games without a detected license render unchanged.

## Why

The monthly sync now pulls a `license` object for every game whose `repository` points at github.com (currently Mindustry, Shapez, Screeps: World, Oort; more will follow). Until the schema and template know about it, the data sits invisible in `src/content/awesome-software-engineering-games/*.json`. Surfacing the SPDX identifier with a link gives visitors a quick signal of which games are open source.

## Test plan

- [x] `make build` (463 pages built, schema accepts existing JSON with and without `license`)
- [ ] `make run` and spot-check `/spiele-fuer-softwareentwickler/`:
  - Mindustry / Shapez / Screeps: World / Oort show a `Lizenz: <SPDX>` bullet linking to the GitHub LICENSE file
  - Satisfactory / Bitburner (no license data) render unchanged — no empty bullet
  - Genre filter pages (e.g. `/spiele-fuer-softwareentwickler/indie-spiele/`) inherit the bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)