### PR TITLE
Don't link tech podcast title/image when no website is set

### DIFF
--- a/src/components/TechPodcastPreview.astro
+++ b/src/components/TechPodcastPreview.astro
@@ -104,9 +104,13 @@ const nameId = URLify(podcast.data.name);
 				}
 
 				<h2 class="mb-8 text-4xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tight">
-					<a href={podcast.data.website} class="hover:underline hover:text-yellow-500" title={`Website von ${podcast.data.name}`}>
-						{podcast.data.name}
-					</a>
+					{podcast.data.website ? (
+						<a href={podcast.data.website} class="hover:underline hover:text-yellow-500" title={`Website von ${podcast.data.name}`}>
+							{podcast.data.name}
+						</a>
+					) : (
+						podcast.data.name
+					)}
 				</h2>
 				<p class="mb-6 text-lg md:text-xl text-coolGray-500 font-medium">
 					{podcast.data.description}
@@ -153,9 +157,13 @@ const nameId = URLify(podcast.data.name);
 			</div>
 			<div class="w-full md:w-4/12 px-4">
 				<div class="relative mx-auto md:mr-0 max-w-max">
-					<a href={podcast.data.website} title={`Website von ${podcast.data.name}`}>
+					{podcast.data.website ? (
+						<a href={podcast.data.website} title={`Website von ${podcast.data.name}`}>
+							<Image class="rounded-2xl" src={podcast.data.image} alt={`Podcast ${podcast.data.name}`} title={`Podcast ${podcast.data.name}`} loading="lazy" decoding="async" format="webp" quality={80} />
+						</a>
+					) : (
 						<Image class="rounded-2xl" src={podcast.data.image} alt={`Podcast ${podcast.data.name}`} title={`Podcast ${podcast.data.name}`} loading="lazy" decoding="async" format="webp" quality={80} />
-					</a>
+					)}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- Some entries in the German tech podcasts directory have no website (e.g. **Co-Op Mode** with `"website": ""`).
- `TechPodcastPreview.astro` unconditionally wrapped the podcast title (`<h2>`) and cover image in `<a href={podcast.data.website}>`, producing `<a href="">` — a self-link that misleads users into thinking a website exists.
- Now the title and image render as plain elements when `website` is empty, and remain linked when a real URL is configured.

## Test plan
- [ ] `make run` and open `/deutsche-tech-podcasts/`; verify the **Co-Op Mode** card has a non-clickable title and image (no hover underline, no link).
- [ ] Spot-check another podcast on the same page: title and image still link to the external website.
- [ ] Open a tag-filtered view (`/deutsche-tech-podcasts/<tag>-podcasts/`) to confirm the same behavior — the component is shared.
- [ ] `make build` completes without Astro errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)