### PR TITLE
ci: Make auto-commit steps resilient to concurrent pushes

### DIFF
--- a/.github/workflows/check-tags-without-descriptions.yml
+++ b/.github/workflows/check-tags-without-descriptions.yml
@@ -38,7 +38,9 @@ jobs:
           ./website-admin tags find awesome-software-engineering-games --write-file
 
       # Commit results back to repository
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Commit changes
+        id: auto-commit
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -47,3 +49,22 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -26,7 +26,9 @@ jobs:
         run: make prettier
 
       # Commit results back to repository
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Commit changes
+        id: auto-commit
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -35,3 +37,21 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1

--- a/.github/workflows/sync-awesome-software-engineering-games.yml
+++ b/.github/workflows/sync-awesome-software-engineering-games.yml
@@ -29,7 +29,9 @@ jobs:
           ./website-admin sync awesome-software-engineering-games
 
       # Commit results back to repository
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Commit changes
+        id: auto-commit
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -38,3 +40,22 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1

--- a/.github/workflows/sync-german-tech-podcasts.yml
+++ b/.github/workflows/sync-german-tech-podcasts.yml
@@ -29,7 +29,9 @@ jobs:
           ./website-admin sync german-tech-podcasts
 
       # Commit results back to repository
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Commit changes
+        id: auto-commit
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -38,3 +40,22 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1

--- a/.github/workflows/update-podcast-episodes-from-rss.yml
+++ b/.github/workflows/update-podcast-episodes-from-rss.yml
@@ -41,7 +41,9 @@ jobs:
             --toml-file netlify.toml
 
       # Commit results back to repository
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - name: Commit changes
+        id: auto-commit
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -50,3 +52,22 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1


### PR DESCRIPTION
## Summary

The `stefanzweifel/git-auto-commit-action` does not pull or rebase before pushing — this is a deliberate non-goal upstream (see the action's README → "Limitations & Gotchas"). When these workflows run concurrently with other actors pushing unrelated changes to `main` (e.g. a different folder), the action's internal `git push` is rejected as non-fast-forward and the workflow fails, even though the changes do not conflict.

This repo is especially exposed: five separate workflows (formatting, tag-SEO check, two external syncs, RSS-driven episode sync) all push to `main` on overlapping schedules and via dispatch.

This PR switches each auto-commit step to `skip_push: true` and adds a small shell retry loop that does `git pull --rebase` between push attempts. The pattern is the same as the one already proven in the `EngineeringKiosk/podcast-metadata` workflows.

The push step uses `working-directory: ${{ github.workspace }}` in workflows whose job sets a job-level `working-directory: website-admin`, so `git push` runs at the repo root.

## Files

- `.github/workflows/check-tags-without-descriptions.yml`
- `.github/workflows/prettier.yml`
- `.github/workflows/sync-awesome-software-engineering-games.yml`
- `.github/workflows/sync-german-tech-podcasts.yml`
- `.github/workflows/update-podcast-episodes-from-rss.yml`

## Test plan

- [ ] All 5 YAML files still parse (workflows show up correctly in the Actions tab after merge)
- [ ] On the next scheduled / dispatched run of each, the new "Push changes with retry" step runs only when `changes_detected == 'true'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)