### PR TITLE
Sitemap improvements: lastmod, image entries, noindex on excluded pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
-import { buildLastmodMap, pathFromSitemapUrl } from './scripts/sitemap-lastmod.mjs';
+import { buildLastmodMap, pathFromSitemapUrl, extractOgImage } from './scripts/sitemap-lastmod.mjs';
 
 // Pages we deliberately keep out of the sitemap. The check is a substring
 // match against the route path, so any sub-route below these prefixes is
@@ -31,8 +31,15 @@ export default defineConfig({
 		sitemap({
 			filter: (page) => !excludeFromSitemap.some((path) => page.includes(path)),
 			serialize: (item) => {
-				const lastmod = lastmodMap.get(pathFromSitemapUrl(SITE, item));
+				const urlPath = pathFromSitemapUrl(SITE, item);
+				const lastmod = lastmodMap.get(urlPath);
 				if (lastmod) item.lastmod = lastmod;
+				// Emit one image per URL, taken from the rendered og:image meta.
+				// That picks the page's own representative image (episode cover
+				// for /podcast/episode/..., page header for index pages, etc.)
+				// without bloating the sitemap with every decorative asset.
+				const og = extractOgImage(SITE, urlPath);
+				if (og) item.img = [{ url: og }];
 				return item;
 			},
 		}),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,19 +2,31 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
+import { buildLastmodMap, pathFromSitemapUrl } from './scripts/sitemap-lastmod.mjs';
 
 // do not add to sitemap if specified string is contained in path
 const exludeFromSitemap = ['meetup/alps/promote/', 'meetup/rhine-ruhr/promote/', 'linktree/'];
 
+// Pre-compute lastmod for content-driven pages once per build. The serialize
+// hook below runs once per URL and must stay synchronous, so the heavy
+// filesystem work happens up front.
+const SITE = 'https://engineeringkiosk.dev/';
+const lastmodMap = buildLastmodMap();
+
 // https://astro.build/config
 export default defineConfig({
 	output: 'static',
-	site: 'https://engineeringkiosk.dev/',
+	site: SITE,
 	trailingSlash: 'always',
 
 	integrations: [
 		sitemap({
 			filter: (page) => !exludeFromSitemap.some((path) => page.includes(path)),
+			serialize: (item) => {
+				const lastmod = lastmodMap.get(pathFromSitemapUrl(SITE, item));
+				if (lastmod) item.lastmod = lastmod;
+				return item;
+			},
 		}),
 		mdx(),
 	],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,8 +4,16 @@ import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
 import { buildLastmodMap, pathFromSitemapUrl } from './scripts/sitemap-lastmod.mjs';
 
-// do not add to sitemap if specified string is contained in path
-const exludeFromSitemap = ['meetup/alps/promote/', 'meetup/rhine-ruhr/promote/', 'linktree/'];
+// Pages we deliberately keep out of the sitemap. The check is a substring
+// match against the route path, so any sub-route below these prefixes is
+// excluded too.
+//
+//   meetup/<flavor>/promote/   short-lived QR-code/campaign pages we share
+//                              from the stage; they exist for a single event
+//                              and should not be indexed.
+//   linktree/                  link-in-bio landing that just redirects to
+//                              other internal pages — no original content.
+const excludeFromSitemap = ['meetup/alps/promote/', 'meetup/rhine-ruhr/promote/', 'linktree/'];
 
 // Pre-compute lastmod for content-driven pages once per build. The serialize
 // hook below runs once per URL and must stay synchronous, so the heavy
@@ -21,7 +29,7 @@ export default defineConfig({
 
 	integrations: [
 		sitemap({
-			filter: (page) => !exludeFromSitemap.some((path) => page.includes(path)),
+			filter: (page) => !excludeFromSitemap.some((path) => page.includes(path)),
 			serialize: (item) => {
 				const lastmod = lastmodMap.get(pathFromSitemapUrl(SITE, item));
 				if (lastmod) item.lastmod = lastmod;

--- a/scripts/sitemap-lastmod.mjs
+++ b/scripts/sitemap-lastmod.mjs
@@ -156,3 +156,28 @@ export function pathFromSitemapUrl(siteUrl, item) {
 		return item.url.replace(siteUrl.replace(/\/$/, ''), '');
 	}
 }
+
+const DIST_DIR = path.join(ROOT, 'dist');
+
+// Reads the rendered HTML for a sitemap URL and returns the og:image absolute
+// URL, or null if the page has none. Runs at sitemap-serialise time, after
+// Astro has already written every page to disk.
+export function extractOgImage(siteUrl, urlPath) {
+	const trimmed = urlPath.replace(/^\/+|\/+$/g, '');
+	const candidate = trimmed
+		? path.join(DIST_DIR, trimmed, 'index.html')
+		: path.join(DIST_DIR, 'index.html');
+	let html;
+	try {
+		html = fs.readFileSync(candidate, 'utf8');
+	} catch {
+		return null;
+	}
+	const m = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i);
+	if (!m) return null;
+	try {
+		return new URL(m[1], siteUrl).toString();
+	} catch {
+		return null;
+	}
+}

--- a/scripts/sitemap-lastmod.mjs
+++ b/scripts/sitemap-lastmod.mjs
@@ -1,0 +1,158 @@
+// Build a URL -> lastmod ISO-string map for use in the @astrojs/sitemap
+// `serialize` hook. Runs once at config-load time and reads the relevant
+// content directories synchronously so the sitemap step can do plain Map
+// lookups.
+//
+// Coverage:
+//   - Podcast episodes:  pubDate from frontmatter
+//   - Blog posts:        pubDate from frontmatter
+//   - Meetup events:     date from frontmatter (Alps + Rhine-Ruhr)
+//   - Aggregate index pages (/podcast/, /blog/, /meetup/alps/, /meetup/rhine-ruhr/,
+//     /deutsche-tech-podcasts/, /filme-fuer-softwareentwickler/, /, ...): max of
+//     their underlying entries' timestamps.
+//
+// Out of scope (kept on default = build time): tag pages, per-genre game
+// pages, per-category/per-type movie pages. Those refresh on every build anyway.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(new URL('..', import.meta.url).pathname);
+
+function readFrontmatterValue(filePath, key) {
+	let text;
+	try {
+		text = fs.readFileSync(filePath, 'utf8');
+	} catch {
+		return null;
+	}
+	const fmMatch = text.match(/^---\s*\n([\s\S]*?)\n---/);
+	if (!fmMatch) return null;
+	const re = new RegExp(`^${key}:\\s*['"]?([^'"\\n]+?)['"]?\\s*$`, 'm');
+	const m = fmMatch[1].match(re);
+	return m ? m[1] : null;
+}
+
+function toIsoOrNull(value) {
+	if (!value) return null;
+	const d = new Date(value);
+	return Number.isFinite(d.getTime()) ? d.toISOString() : null;
+}
+
+function listMatchingFiles(dir, regex) {
+	const abs = path.join(ROOT, dir);
+	if (!fs.existsSync(abs)) return [];
+	return fs
+		.readdirSync(abs)
+		.filter((f) => regex.test(f))
+		.map((f) => ({ name: f, full: path.join(abs, f) }));
+}
+
+function maxIso(values) {
+	let max = null;
+	for (const v of values) {
+		if (!v) continue;
+		if (!max || v > max) max = v;
+	}
+	return max;
+}
+
+function readJson(filePath) {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+	} catch {
+		return null;
+	}
+}
+
+function stripExtension(name) {
+	return name.replace(/\.(md|mdx|json)$/i, '');
+}
+
+export function buildLastmodMap() {
+	const map = new Map();
+	const set = (urlPath, iso) => {
+		if (iso) map.set(urlPath, iso);
+	};
+
+	// --- Podcast episodes ----------------------------------------------------
+	const episodeIsos = [];
+	for (const { name, full } of listMatchingFiles('src/content/podcast', /\.md$/)) {
+		const iso = toIsoOrNull(readFrontmatterValue(full, 'pubDate'));
+		if (iso) {
+			episodeIsos.push(iso);
+			set(`/podcast/episode/${stripExtension(name)}/`, iso);
+		}
+	}
+	const newestEpisode = maxIso(episodeIsos);
+	set('/podcast/', newestEpisode);
+	// The homepage prominently surfaces the latest episode.
+	set('/', newestEpisode);
+
+	// --- Blog posts ----------------------------------------------------------
+	const blogIsos = [];
+	for (const { name, full } of listMatchingFiles('src/content/blog', /\.(md|mdx)$/)) {
+		const iso = toIsoOrNull(readFrontmatterValue(full, 'pubDate'));
+		if (iso) {
+			blogIsos.push(iso);
+			set(`/blog/post/${stripExtension(name)}/`, iso);
+		}
+	}
+	set('/blog/', maxIso(blogIsos));
+
+	// --- Meetup events -------------------------------------------------------
+	for (const flavor of ['alps', 'rhine-ruhr']) {
+		const isos = [];
+		for (const { name, full } of listMatchingFiles(`src/content/meetup-${flavor}`, /\.(md|mdx)$/)) {
+			const iso = toIsoOrNull(readFrontmatterValue(full, 'date'));
+			if (iso) {
+				isos.push(iso);
+				set(`/meetup/${flavor}/${stripExtension(name)}/`, iso);
+			}
+		}
+		set(`/meetup/${flavor}/`, maxIso(isos));
+	}
+
+	// --- German Tech Podcasts directory -------------------------------------
+	const gtpIsos = [];
+	for (const { full } of listMatchingFiles('src/content/germantechpodcasts', /\.json$/)) {
+		const data = readJson(full);
+		const epoch = data?.latestEpisodePublished;
+		if (typeof epoch === 'number' && epoch > 0) {
+			gtpIsos.push(new Date(epoch * 1000).toISOString());
+		}
+	}
+	set('/deutsche-tech-podcasts/', maxIso(gtpIsos));
+
+	// --- Movies directory ----------------------------------------------------
+	const movieIsos = [];
+	for (const { full } of listMatchingFiles('src/content/awesome-software-engineering-movies', /\.json$/)) {
+		const data = readJson(full);
+		const iso = toIsoOrNull(data?.publishedAt);
+		if (iso) movieIsos.push(iso);
+	}
+	set('/filme-fuer-softwareentwickler/', maxIso(movieIsos));
+
+	// --- Games directory -----------------------------------------------------
+	const gameIsos = [];
+	for (const { full } of listMatchingFiles('src/content/awesome-software-engineering-games', /\.json$/)) {
+		const data = readJson(full);
+		const iso = toIsoOrNull(data?.release_date?.date);
+		if (iso) gameIsos.push(iso);
+	}
+	set('/spiele-fuer-softwareentwickler/', maxIso(gameIsos));
+
+	return map;
+}
+
+export function pathFromSitemapUrl(siteUrl, item) {
+	// item.url is the full canonical URL (e.g. https://engineeringkiosk.dev/foo/).
+	// Sitemaps emit percent-encoded paths; decode so we can match raw filenames
+	// (umlauts in German episode slugs).
+	try {
+		const u = new URL(item.url);
+		return decodeURI(u.pathname);
+	} catch {
+		return item.url.replace(siteUrl.replace(/\/$/, ''), '');
+	}
+}

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -13,9 +13,14 @@ export interface Props {
 	profileFirstName?: string;
 	profileLastName?: string;
 	jsonLd?: Record<string, unknown>;
+	// When true, signal to search engines that this page should not be indexed
+	// or its outbound links followed. Use for short-lived campaign pages,
+	// duplicate content (e.g. /linktree/), or anything also kept out of the
+	// sitemap via astro.config.mjs `excludeFromSitemap`.
+	noindex?: boolean;
 }
 
-const { title, description, image, canonicalURL, ogType, ogImageAlt, ogImageWidth, ogImageHeight, profileFirstName, profileLastName, jsonLd } = Astro.props as Props;
+const { title, description, image, canonicalURL, ogType, ogImageAlt, ogImageWidth, ogImageHeight, profileFirstName, profileLastName, jsonLd, noindex } = Astro.props as Props;
 
 let ogTypeValue = 'website';
 if (ogType) {
@@ -29,7 +34,11 @@ if (ogType) {
 <title>{title}</title>
 <meta name="description" content={description} />
 
-<meta name="robots" content="follow, index, max-snippet:-1, max-video-preview:-1, max-image-preview:large" />
+{noindex ? (
+	<meta name="robots" content="noindex, nofollow" />
+) : (
+	<meta name="robots" content="follow, index, max-snippet:-1, max-video-preview:-1, max-image-preview:large" />
+)}
 
 <link rel="dns-prefetch" href="https://piwik.inlupus.at" />
 

--- a/src/components/meetup/PromoteAnnounceNewsletter.astro
+++ b/src/components/meetup/PromoteAnnounceNewsletter.astro
@@ -32,7 +32,7 @@ const locationAddress = nextMeetup?.location.address;
 <html lang="de">
 
 	<head>
-		<MainHead title={title} description={description} image={ogImage} {canonicalURL} />
+		<MainHead title={title} description={description} image={ogImage} {canonicalURL} noindex />
 	</head>
 
 	<body class="antialiased bg-body text-body">

--- a/src/components/meetup/PromoteNewsletter.astro
+++ b/src/components/meetup/PromoteNewsletter.astro
@@ -1,6 +1,4 @@
 ---
-import MainHead from '../MainHead.astro';
-
 import { formatTime, monthSuffixedDay, year} from '../../scripts/date.js';
 import { createMeetupHelpers } from '../../scripts/meetups.js';
 
@@ -31,6 +29,9 @@ const locationAddress = nextMeetup?.location.address;
 ---
 
 <html lang="de">
+	<head>
+		<meta name="robots" content="noindex, nofollow" />
+	</head>
 	<body class="antialiased bg-body text-body">
 
 		<h1 class="text-xl font-bold">Engineering Kiosk Meetup Announcement{nextMeetup ? ` - ${dateStringMonthDay}` : ''}</h1>

--- a/src/components/meetup/PromoteSocialImage.astro
+++ b/src/components/meetup/PromoteSocialImage.astro
@@ -31,7 +31,7 @@ const defaultAvatarPath = `/meetup/${meetupUrl}/images/speaker/avatar.png`;
 
 <html lang="de">
 	<head>
-		<MainHead title={title} description={description} image={ogImage} {canonicalURL} />
+		<MainHead title={title} description={description} image={ogImage} {canonicalURL} noindex />
 	</head>
 
 	<body class="antialiased bg-body text-body font-body">

--- a/src/pages/linktree.astro
+++ b/src/pages/linktree.astro
@@ -40,7 +40,7 @@ const latestEpisodes = [
 
 <html lang="de">
 	<head>
-		<MainHead title={title} description={description} image="/images/logos/pocast-episode-logo-cover.jpg" {canonicalURL} />
+		<MainHead title={title} description={description} image="/images/logos/pocast-episode-logo-cover.jpg" {canonicalURL} noindex />
 	</head>
 
 	<body class="antialiased bg-body text-body font-body">


### PR DESCRIPTION
## Summary

Four isolated commits on `andygrunwald/sitemap-improvements`, addressing the sitemap audit:

1. **`3bfe4136` — Emit `<lastmod>` for content-driven pages.** New build-time helper `scripts/sitemap-lastmod.mjs` walks the relevant content directories synchronously, parses `pubDate` / `date` / `publishedAt` / `latestEpisodePublished` out of frontmatter or JSON, and exposes a `Map<urlPath, ISO>` for the sitemap `serialize` hook. Coverage: podcast episodes, blog posts, meetup events, and the matching index pages (`/podcast/`, `/blog/`, `/meetup/<flavor>/`, `/deutsche-tech-podcasts/`, `/filme-fuer-softwareentwickler/`, `/spiele-fuer-softwareentwickler/`, `/`). Tag pages and per-genre/category routes fall back to build time. **277 of 464 URLs now carry `<lastmod>`.**

2. **`ecf00e96` — Document the exclude list and fix the typo.** Renamed `exludeFromSitemap` → `excludeFromSitemap` and added a comment block explaining each entry (`meetup/<flavor>/promote/` for short-lived QR-code campaign pages, `linktree/` for a redirect-only landing). No behaviour change.

3. **`800158d5` — Mark sitemap-excluded pages as `noindex,nofollow`.** Defence-in-depth: the exclude list keeps these URLs out of `sitemap-0.xml`, but Google can still discover them via inbound QR-code links. Added a `noindex` boolean prop to `MainHead.astro`; passed it from the four affected templates (`linktree`, `PromoteSocialImage`, `PromoteAnnounceNewsletter`, `PromoteNewsletter`). Drive-by: `PromoteNewsletter` had a dead `MainHead` import and no `<head>` at all — added a small inline `<head>` with the noindex meta and dropped the unused import.

4. **`2274501c` — Emit image sitemap entries from each page's og:image.** New `extractOgImage` helper reads the rendered HTML for each URL and attaches one image entry per URL via the `image:` namespace. **458 of 464 URLs now carry an `<image:loc>`.** Per-page selections look right: episode covers for `/podcast/episode/...`, hosts photo for `/`, dedicated headers for the directory pages.

## Test plan

- [x] `make build` green at 472 pages.
- [x] Sitemap exclude list still keeps `/linktree/` and `meetup/*/promote/` out of the sitemap (0 leaks).
- [x] All 7 excluded URLs now ship `<meta name="robots" content="noindex, nofollow">`; all other pages keep the original index-promoting tag.
- [x] Spot-checks on lastmod: `/podcast/` = newest episode pubDate, `/blog/post/<slug>/` = entry pubDate, `/impressum/` correctly lacks a lastmod.
- [x] Spot-checks on og:image: episode covers come through as `/_astro/<slug>.<hash>.jpg`; homepage uses the hosts photo.
- [ ] Validate emitted XML against the schemas at https://www.sitemaps.org/protocol.html and https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps once deployed.
- [ ] Re-submit the sitemap in Google Search Console after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)