### PR TITLE
Meetup Stats: Link date column to the matching archive entry

### DIFF
--- a/src/components/meetup/MeetupArchiveEvent.astro
+++ b/src/components/meetup/MeetupArchiveEvent.astro
@@ -2,14 +2,14 @@
 import type { CollectionEntry } from 'astro:content';
 import CompanyLogo from '../meetup/CompanyLogo.astro';
 import MeetupArchiveEventTalk from './MeetupArchiveEventTalk.astro';
-import { formatDateWithoutWeekday } from '../../scripts/date.js';
+import { formatDateWithoutWeekday, meetupArchiveAnchor } from '../../scripts/date.js';
 
 export interface Props {
 	meetup: CollectionEntry<'meetup'>;
 }
 
 const { meetup } = Astro.props;
-const meetupId = `meetup-${formatDateWithoutWeekday(meetup.date, 'en-GB').toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+const meetupId = meetupArchiveAnchor(meetup.date);
 
 ---
 <a href={`#${meetupId}`} class="block flex flex-col md:flex-row border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-all cursor-pointer bg-white hover:bg-yellow-50 no-underline text-inherit">

--- a/src/components/meetup/MeetupListing.astro
+++ b/src/components/meetup/MeetupListing.astro
@@ -3,7 +3,7 @@
 import MeetupEvent from './MeetupEvent.astro';
 import Talk from './Talk.astro';
 
-import { formatDateWithoutWeekday } from '../../scripts/date.js';
+import { formatDateWithoutWeekday, meetupArchiveAnchor } from '../../scripts/date.js';
 import CompanyLogo from './CompanyLogo.astro';
 
 export interface Props {
@@ -25,7 +25,7 @@ const { headline, meetupsToShow, archive, meetupName, meetupSlug, meetupImage, s
 	{
 		meetupsToShow.map((meetup, i) => (
 			<>
-				<div class="container px-4 mx-auto" id={`meetup-${formatDateWithoutWeekday(meetup.date, 'en-GB').toLowerCase().replace(/[^a-z0-9-]/g, '-')}`}>
+				<div class="container px-4 mx-auto" id={meetupArchiveAnchor(meetup.date)}>
 					<div class="mb-16 text-center">
 						<span class="inline-block py-px px-2 mb-4 text-xs leading-5 text-yellow-500 bg-yellow-100 font-medium uppercase rounded-9xl">{headline}</span>
 						<h1 class="mb-4 text-3xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tight">

--- a/src/components/meetup/MeetupStatsLayout.astro
+++ b/src/components/meetup/MeetupStatsLayout.astro
@@ -1,6 +1,6 @@
 ---
 import MainHead from '../MainHead.astro';
-import { formatDate } from '../../scripts/date.js';
+import { formatDate, meetupArchiveAnchor } from '../../scripts/date.js';
 import { createMeetupHelpers } from '../../scripts/meetups.js';
 
 export interface Props {
@@ -12,6 +12,7 @@ export interface Props {
 }
 
 const { collectionName, meetupName, pageTitle, pageDescription, ogImage } = Astro.props;
+const meetupSlug = collectionName.replace(/^meetup-/, '');
 
 const { getNextMeetup, getPastMeetups } = await createMeetupHelpers(collectionName);
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -97,7 +98,15 @@ speakerStats.nonbinaryPercentage = Math.round((speakerStats.nonbinary / speakerS
                     <tbody>
                         {allMeetups.map((meetup) => (
                             <tr class="hover:bg-gray-50">
-                                <td class="px-6 py-4 border-b">{formatDate(meetup.date)}</td>
+                                <td class="px-6 py-4 border-b">
+                                    {new Date(meetup.date) <= new Date() ? (
+                                        <a href={`/meetup/${meetupSlug}/archive/#${meetupArchiveAnchor(meetup.date)}`} class="text-yellow-500 hover:underline">
+                                            {formatDate(meetup.date)}
+                                        </a>
+                                    ) : (
+                                        formatDate(meetup.date)
+                                    )}
+                                </td>
                                 <td class="px-6 py-4 border-b">{meetup.location.name}</td>
                                 <td class="px-6 py-4 border-b">
                                     {meetup.talks.filter(t => t._announced).map(talk => `${talk.name} (${talk.title})`).join(', ') || 'no data'}

--- a/src/scripts/date.js
+++ b/src/scripts/date.js
@@ -29,6 +29,12 @@ export function formatDateWithoutWeekday(date, locale = 'de-DE') {
 	return new Date(date).toLocaleDateString(locale, options);
 }
 
+// returns the anchor id used by MeetupListing/MeetupArchiveEvent so callers
+// can build links to a specific meetup, e.g. "meetup-29-april-2026"
+export function meetupArchiveAnchor(date) {
+	return `meetup-${formatDateWithoutWeekday(date, 'en-GB').toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+}
+
 // returns the time in the format HH:MM
 export function formatTime(date, locale = 'de-DE', timeZone = 'Europe/Berlin') {
 	const options = {


### PR DESCRIPTION
## Summary

- The stats tables at `/meetup/rhine-ruhr/stats/` and `/meetup/alps/stats/` were a dead end — a reader who noticed an interesting row had to navigate to the archive page manually and scroll for the matching date.
- The **Date** cell in each past-meetup row is now a link to the corresponding anchor on the archive page (e.g. `/meetup/alps/archive/#meetup-7-may-2026`). The upcoming-meetup row stays plain text, since the archive (fed by `getPastMeetups()`) does not yet include it.
- The anchor format (`meetup-<dd>-<month>-<yyyy>`) was already produced by `MeetupListing.astro` and `MeetupArchiveEvent.astro`. To avoid a third inline copy of the same formula drifting independently, the formula moves into a small `meetupArchiveAnchor()` helper in `src/scripts/date.js`, and both existing producers switch to it. Rendered `id` attributes on archive and homepage stay byte-identical.
- Region slug for the link target is derived from `collectionName` (`meetup-alps` → `alps`); no new prop wiring needed.

## Test plan

- [x] `make build` — site builds (475 pages)
- [x] `make test-javascript` — 55/55 vitest tests pass
- [x] Verified rendered HTML: 32 archive links on `/meetup/alps/stats/`, 2 on `/meetup/rhine-ruhr/stats/`, both pointing at the correct anchors
- [ ] In dev server, click a date on `/meetup/alps/stats/` → page navigates to `/meetup/alps/archive/#meetup-…` and scrolls to the matching meetup card
- [ ] Same check on `/meetup/rhine-ruhr/stats/`
- [ ] If an upcoming-meetup row is shown, its date is plain text (no link)
- [ ] `/meetup/alps/archive/`, `/meetup/rhine-ruhr/archive/`, `/meetup/alps/`, `/meetup/rhine-ruhr/` still render with the same `id="meetup-…"` attributes (helper extraction is byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)