### PR TITLE
Meetup: Show archive link on homepage even without an upcoming meetup

### DIFF
--- a/src/components/meetup/MeetupListing.astro
+++ b/src/components/meetup/MeetupListing.astro
@@ -14,9 +14,10 @@ export interface Props {
 	meetupSlug: string;
 	meetupImage: string;
 	showGeneralLanguageNote?: boolean;
+	hasPastMeetups?: boolean;
 }
 
-const { headline, meetupsToShow, archive, meetupName, meetupSlug, meetupImage, showGeneralLanguageNote = false } = Astro.props
+const { headline, meetupsToShow, archive, meetupName, meetupSlug, meetupImage, showGeneralLanguageNote = false, hasPastMeetups = false } = Astro.props
 
 
 ---
@@ -42,14 +43,6 @@ const { headline, meetupsToShow, archive, meetupName, meetupSlug, meetupImage, s
 							<Talk talk={talk} meetupSlug={meetupSlug} />
 						))}
 					</div>
-					{!archive && (
-						<div class="text-center mt-8 text-lg md:text-xl text-coolGray-500 font-medium">
-							Find previous talks in the{' '}
-							<a href="./archive/" class="text-yellow-500">
-								Engineering Kiosk {meetupName} Talks Archive
-							</a>
-						</div>
-					)}
 				</div>
         {meetup && meetup.talks && meetup.talks[0] && meetup.talks[0].name && meetup.talks[0].title && meetup.location.name && meetup.location.address && (
 				    <MeetupEvent event={meetup} meetupName={meetupName} meetupSlug={meetupSlug} meetupImage={meetupImage} />
@@ -57,4 +50,12 @@ const { headline, meetupsToShow, archive, meetupName, meetupSlug, meetupImage, s
 			</>
 		))
 	}
+	{!archive && hasPastMeetups && (
+		<div class="container px-4 mx-auto text-center mt-8 text-lg md:text-xl text-coolGray-500 font-medium">
+			Find previous talks in the{' '}
+			<a href="./archive/" class="text-yellow-500">
+				Engineering Kiosk {meetupName} Talks Archive
+			</a>
+		</div>
+	)}
 </section>

--- a/src/components/meetup/MeetupPageLayout.astro
+++ b/src/components/meetup/MeetupPageLayout.astro
@@ -55,10 +55,11 @@ const {
 } = Astro.props;
 
 const meetupSlug = collectionName.replace('meetup-', '');
-const { getNextMeetup } = await createMeetupHelpers(collectionName);
+const { getNextMeetup, getPastMeetups } = await createMeetupHelpers(collectionName);
 
 const bufferDays = 1;
 const nextMeetup = getNextMeetup(bufferDays);
+const hasPastMeetups = getPastMeetups().length > 0;
 const dateString = nextMeetup ? formatDateWithoutWeekday(nextMeetup.date, 'en-US') : null;
 const timeString = nextMeetup ? formatTime(nextMeetup.date) : null;
 const dateAndTime = nextMeetup ? `${dateString} - open doors at ${timeString} (talks start ~30min later)` : null;
@@ -180,7 +181,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 				</div>
 			</section>
 
-			<MeetupListing meetupsToShow={nextMeetup ? [nextMeetup] : []} headline='Awesome Community Talks' meetupName={meetupName} meetupSlug={meetupSlug} meetupImage={ogImage} showGeneralLanguageNote={showGeneralLanguageNote} />
+			<MeetupListing meetupsToShow={nextMeetup ? [nextMeetup] : []} headline='Awesome Community Talks' meetupName={meetupName} meetupSlug={meetupSlug} meetupImage={ogImage} showGeneralLanguageNote={showGeneralLanguageNote} hasPastMeetups={hasPastMeetups} />
 
 			{ () => {
 				if (!nextMeetup) {


### PR DESCRIPTION
## Summary

- The "Find previous talks in the Engineering Kiosk <Region> Talks Archive" link is the homepage's only entry point to past talks. Until now it lived inside `MeetupListing`'s `meetupsToShow.map(...)` body, so it vanished whenever a region had no upcoming meetup to render — the exact moment a returning visitor most needs it. Rhine-Ruhr currently has only past events, so its homepage offered no path to the archive at all.
- Pulled the link out of the per-meetup loop and render it once at the section level in `MeetupListing.astro`. Gated on `!archive && hasPastMeetups` so the archive page itself still suppresses the link (already wired via `archive={true}` in `MeetupArchiveLayout`) and so we don't link to an empty archive if a region ever has no past meetups yet.
- `hasPastMeetups` is derived in `MeetupPageLayout` via `getPastMeetups().length > 0` and passed in as a prop, keeping `MeetupListing` as a presenter without a new `createMeetupHelpers` dependency.
- **Visual side effect on Alps** (which has both past and upcoming meetups): the link moves from inside the upcoming-meetup container to just below the rendered `MeetupEvent`. Same section, same styling, same target URL — only the relative DOM position shifts a few elements down.

## Test plan

- [x] `make build` — 475 pages built green
- [x] `make test-javascript` — 55/55 vitest tests pass
- [x] Verified in rendered HTML: `/meetup/alps/` and `/meetup/rhine-ruhr/` both contain the archive link; `/meetup/alps/archive/` and `/meetup/rhine-ruhr/archive/` do **not** (suppressed by `archive={true}`)
- [ ] In dev server, visit `/meetup/rhine-ruhr/` and confirm the new "Find previous talks…" link is visible and navigates to `/meetup/rhine-ruhr/archive/`
- [ ] Visit `/meetup/alps/` and confirm the link still works and lands on the same target as before
- [ ] Visit both `/archive/` pages and confirm the link is **not** shown (no double link on the archive page itself)
- [ ] Edge case: if a region ever has no past meetups, the link should be hidden — guarded by `hasPastMeetups=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)