### PR TITLE
Fix lychee config

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,4 +1,3 @@
-exclude_mail = true
 exclude_path = ["./src/content/podcast/"]
 # x.com often blocks automated link checkers
 exclude = [ '.*x\.com.*' ]


### PR DESCRIPTION
Lychee currently has an invalid config setting. The related job shows errors in the logs:

https://github.com/EngineeringKiosk/webpage/actions/runs/25338080458/job/74288344228#step:3:87

This change removes that setting (there is `enable_email`, which defaults to false).

However:

The corresponding `linkChecker` job can not fail:

https://github.com/psytrx/webpage-add-fragment-checks/blob/c70bfd02e740ba7a718743d60f19625ced997c8a/.github/workflows/links.yml#L18

Might be for good reason (exclude list maintenance burden, notification noise, ...), so I'm leaving this as is. I still think the job should at least attempt to run. :)