### PR TITLE
Align Rhine-Ruhr 'no upcoming meetup' hero with Alps design

### DIFF
--- a/src/components/meetup/MeetupPageLayout.astro
+++ b/src/components/meetup/MeetupPageLayout.astro
@@ -143,9 +143,9 @@ const headTitle = (() => {
 									</>
 								) : (
 									<>
-										<h2 class="text-lg md:text-2xl text-coolGray-500 font-medium">Next Meetup: To be announced</h2>
+										<h2 class="text-lg md:text-2xl text-coolGray-500 font-medium">Next Meetup: In Planning</h2>
 										<p class="mt-2 mb-8 text-sm md:text-base text-coolGray-500 font-medium">
-											We are working on the next meetup. <a class="text-yellow-500 underline" data-scroll-to="a[name=newsletter]" href="#newsletter">Subscribe</a> to get notified as soon as the date is set.
+											📋 We're currently planning the next Engineering Kiosk {meetupName} meetup. Date and venue will be announced soon.
 										</p>
 									</>
 								)}
@@ -154,7 +154,22 @@ const headTitle = (() => {
 									<div class="w-full md:w-auto py-1 md:py-0 md:mr-4">
 									{ () => {
 										if (!nextMeetup) {
-											return null;
+											return(
+												<>
+													<a
+														class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 text-yellow-50 font-medium text-center bg-yellow-500 hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-500 focus:ring-opacity-50 border border-yellow-500 rounded-md shadow-sm"
+														data-scroll-to="a[name=newsletter]"
+														href="#newsletter"
+													>
+														Subscribe to Newsletter
+													</a>
+													<p class="mt-12 mb-2 md:mb-8 text-lg text-coolGray-500 font-medium">
+														<a class="text-yellow-500" data-scroll-to="a[name=newsletter]" href="#newsletter">
+															<span class="underline">Subscribe</span> and get an email when the next meetup is announced.
+														</a>
+													</p>
+												</>
+											);
 										}
 										if (!registrationClosed) {
 											return(


### PR DESCRIPTION
## Summary

- Restyles the `!nextMeetup` fallback in the shared `MeetupPageLayout.astro` so the Rhine-Ruhr hero matches the Alps "Next Meetup @ Venue" treatment instead of the weak single-line "To be announced" copy.
- Heading becomes **"Next Meetup: In Planning"** (active voice), the body paragraph names the meetup via the existing `meetupName` prop, and a yellow **"Subscribe to Newsletter"** CTA now occupies the same slot Alps uses for its "Register for next meetup" button — same Tailwind classes for pixel-perfect parity, with the matching "Subscribe and get an email…" reinforcement link below.
- Change is in the shared component, so both regions degrade gracefully if either ever has no scheduled meetup. Currently only Rhine-Ruhr renders the new fallback; Alps still has the June 11 event and its hero is unchanged.

## Notes

- The CTA scrolls to the existing `#newsletter` anchor (rendered unconditionally by `Newsletter.astro`). Making the in-page subscribe form visible on Rhine-Ruhr (`showNewsletterForm={true}`) is handled in a separate branch.
- No schema, prop, or page-level changes — purely a visual/copy fix in the fallback branch.

## Test plan

- [x] `make build` — 476 pages built, no errors
- [x] `make test-javascript` — 60/60 pass
- [ ] Local `make run` → `/meetup/rhine-ruhr/` shows the new "In Planning" heading, body paragraph, yellow Subscribe button, and reinforcement link
- [ ] Local `make run` → `/meetup/alps/` hero is unchanged (still "Next Meetup @ Data Lab Hell" with date/location/Register button)
- [ ] After the parallel branch lands enabling `showNewsletterForm={true}` for Rhine-Ruhr, verify the new CTA scrolls to a visible newsletter form on the same page

🤖 Generated with [Claude Code](https://claude.com/claude-code)