### PR TITLE
Show 'in planning' copy when no tentative meetup dates exist

### DIFF
--- a/src/components/meetup/Newsletter.astro
+++ b/src/components/meetup/Newsletter.astro
@@ -70,16 +70,30 @@ let dates = getNextMeetups().map((meetup) => meetup.date);
 	</div>
 	<div class="container px-4 mx-auto w-full md:w-1/2">
 		<div class="mb-16 text-center">
-			<h4 class="mb-4 text-xl md:text-xl leading-tight text-coolGray-900 font-bold tracking-tight">Upcoming tentative meetups:</h4>
-			<p class="text-lg md:text-xl text-coolGray-500 font-medium">
-				{dates.map((date) =>
-					<b>{formatDateWithoutWeekday(date, 'en-US')}</b><br/>
-				)}
-			{showForm && (
-				<br/>
-				<Fragment>Please register to the Newsletter to get notified when the talk dates get fixed, as those are preliminary.</Fragment>
+			{dates.length > 0 ? (
+				<>
+					<h4 class="mb-4 text-xl md:text-xl leading-tight text-coolGray-900 font-bold tracking-tight">Upcoming tentative meetups:</h4>
+					<p class="text-lg md:text-xl text-coolGray-500 font-medium">
+						{dates.map((date) =>
+							<b>{formatDateWithoutWeekday(date, 'en-US')}</b><br/>
+						)}
+					{showForm && (
+						<br/>
+						<Fragment>Please register to the Newsletter to get notified when the talk dates get fixed, as those are preliminary.</Fragment>
+					)}
+					</p>
+				</>
+			) : (
+				<>
+					<h4 class="mb-4 text-xl md:text-xl leading-tight text-coolGray-900 font-bold tracking-tight">Next meetup dates: In Planning</h4>
+					<p class="text-lg md:text-xl text-coolGray-500 font-medium">
+						📋 We're working on confirming the next Engineering Kiosk {meetupDisplayName} meetup dates.
+						{showForm && (
+							<Fragment><br/>Please register to the Newsletter to get notified as soon as the dates are confirmed.</Fragment>
+						)}
+					</p>
+				</>
 			)}
-			</p>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
## Summary

- Wraps the "Upcoming tentative meetups:" block in `Newsletter.astro` with a `dates.length > 0` ternary so an empty meetup collection no longer leaves a dangling, list-less header on the page.
- Empty branch shows **"Next meetup dates: In Planning"** with a 📋 paragraph naming the meetup via the existing `meetupDisplayName` prop — same voice and Tailwind treatment as the hero from #1447, so the Rhine-Ruhr page now reads coherently top-to-bottom.
- Reworded the `showForm` reminder for the empty case from *"…when the talk dates get fixed, as those are preliminary"* → *"…as soon as the dates are confirmed"*, since the original copy assumed preliminary dates that don't exist.

## Notes

- Truthy branch (when meetups exist) renders byte-identically to today, so Alps is unchanged.
- No schema, helper, or prop changes — entirely a presentation-layer fix.
- Pairs with #1447 (hero) and the user's parallel branch enabling `showNewsletterForm={true}` for Rhine-Ruhr.

## Test plan

- [x] `make build` — 476 pages built, no errors
- [x] `make test-javascript` — 60/60 pass
- [ ] Local `make run` → `/meetup/rhine-ruhr/` newsletter section now shows "Next meetup dates: In Planning" with the 📋 paragraph
- [ ] Local `make run` → `/meetup/alps/` newsletter section is unchanged (still "Upcoming tentative meetups:" with the existing date list and reminder)
- [ ] Once `showNewsletterForm={true}` lands for Rhine-Ruhr, verify the empty-state reminder line ("…as soon as the dates are confirmed") renders below the 📋 paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)