### PR TITLE
Migrate Alps meetup newsletter to the Worker-backed solution

### DIFF
--- a/src/pages/meetup/alps/index.astro
+++ b/src/pages/meetup/alps/index.astro
@@ -1,5 +1,6 @@
 ---
 import MeetupPageLayout from '../../../components/meetup/MeetupPageLayout.astro';
+import { NEWSLETTER_SOURCES, NEWSLETTER_LISTS, NEWSLETTER_LOCALES } from '../../../scripts/newsletter-constants.js';
 
 // Dynamically import all images from the slider directory
 const imageModules = import.meta.glob('../../../images/meetup-alps/slider/*.{jpg,jpeg,png,webp,avif}', { eager: true });
@@ -24,6 +25,7 @@ const sliderImages = Object.entries(imageModules).map(([path, module]) => ({
 	showRegistrationForm={true}
 	showGeneralLanguageNote={true}
 	showNewsletterForm={true}
+	newsletterConfig={{ source: NEWSLETTER_SOURCES.MEETUP, locale: NEWSLETTER_LOCALES.EN, primaryNewsletter: NEWSLETTER_LISTS.MEETUP_ALPS }}
 	regionDescription="tech people in Tyrol"
 	teamBadge="The local team in Innsbruck"
 	teamTitle="Team Engineering Kiosk Alps"

--- a/src/scripts/newsletter-constants.js
+++ b/src/scripts/newsletter-constants.js
@@ -20,6 +20,7 @@ export const NEWSLETTER_SOURCES = {
 
 export const NEWSLETTER_LISTS = {
 	MEETUP_RHINE_RUHR: 'meetup_rhine_ruhr',
+	MEETUP_ALPS: 'meetup_alps',
 };
 
 export const NEWSLETTER_LOCALES = {


### PR DESCRIPTION
## What

Migrates the newsletter signup form on the [Alps meetup page](https://engineeringkiosk.dev/meetup/alps/) from the legacy backend to the new Cloudflare Worker solution — the same one already used by the [Rhine-Ruhr meetup page](https://engineeringkiosk.dev/meetup/rhine-ruhr/).

## Why

The Alps newsletter form still POSTed form-encoded data to the deprecated `rsvp.engineeringkiosk.dev/newsletter` endpoint. That backend is no longer supported, so Alps newsletter signups were effectively lost. Rhine-Ruhr already moved to the Worker (`api.engineeringkiosk.dev/newsletter/subscribe`, Plunk integration); this brings Alps in line.

## How

`MeetupPageLayout.astro` already renders `NewsletterWorker.astro` instead of the legacy `Newsletter.astro` whenever a `newsletterConfig` prop is present. So the migration is purely configuration — no layout or component changes:

- `src/scripts/newsletter-constants.js` — add `MEETUP_ALPS: 'meetup_alps'` to `NEWSLETTER_LISTS`.
- `src/pages/meetup/alps/index.astro` — add the `newsletterConfig` prop (`source: website-meetup`, `locale: en`, `primaryNewsletter: meetup_alps`).

The "Please, let us know that you are coming" meetup registration form is intentionally left untouched.

## Behavior after merge

- Alps newsletter form POSTs JSON to the Worker, identical to Rhine-Ruhr.
- Adds the default-checked "Also subscribe to the general Engineering Kiosk newsletter (German)" checkbox and "(in English)" description suffix — matching Rhine-Ruhr.
- Honeypot bot protection + email validation now apply.

## ⚠️ Requires before merge

The `meetup_alps` list **must exist in the `engineeringkiosk/newsletter-worker`** Cloudflare Worker. A missing list silently drops signups (per the warning in `newsletter-constants.js`).

## Verification

- `make build` — site builds cleanly (476 pages).
- `make test-javascript` — 86 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)