### PR TITLE
Reword meetup newsletter intro and add events-notification checkbox

### DIFF
--- a/src/components/meetup/NewsletterWorker.astro
+++ b/src/components/meetup/NewsletterWorker.astro
@@ -45,6 +45,7 @@ const inputId = `meetup-newsletter-email-${idSuffix}`;
 const statusId = `meetup-newsletter-status-${idSuffix}`;
 const honeypotId = `meetup-newsletter-company-${idSuffix}`;
 const checkboxId = `meetup-newsletter-also-${idSuffix}`;
+const eventsCheckboxId = `meetup-newsletter-events-${idSuffix}`;
 const configId = `${formElementId}-config`;
 
 const messages = {
@@ -75,7 +76,8 @@ const config = {
 			<h3 class="mb-4 text-3xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tight">Interested in upcoming meetups?</h3>
 			{showForm && (
 				<p class="text-lg md:text-xl text-coolGray-500 font-medium">
-					Register to our Engineering Kiosk {meetupDisplayName} newsletter (in English) and receive emails about upcoming meetups.<br />
+					Register to our Engineering Kiosk {meetupDisplayName} newsletter (in English).<br />
+					Receive updates about upcoming meetups.<br />
 					No worries, we won't spam you and you can unsubscribe at any time.
 				</p>
 
@@ -93,6 +95,12 @@ const config = {
 						/>
 						<input id={honeypotId} type="text" name="company" tabindex="-1" autocomplete="off" aria-hidden="true" class="absolute left-[-9999px] h-0 w-0 opacity-0" />
 						<button type="submit" class="py-4 px-5 leading-4 cursor-pointer text-yellow-50 font-medium text-center bg-yellow-500 hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-500 focus:ring-opacity-50 rounded-md shadow-sm disabled:opacity-60 disabled:cursor-not-allowed">Subscribe</button>
+					</div>
+					<div class="max-w-xl mx-auto mt-3 flex justify-center">
+						<label for={eventsCheckboxId} class="inline-flex items-center text-base text-coolGray-500 font-medium">
+							<input id={eventsCheckboxId} type="checkbox" checked disabled class="mr-2" />
+							Get notified about upcoming events
+						</label>
 					</div>
 					<div class="max-w-xl mx-auto mt-3 flex justify-center">
 						<label for={checkboxId} class="inline-flex items-center text-base text-coolGray-500 font-medium cursor-pointer">


### PR DESCRIPTION
## What

Two UX changes to the meetup newsletter signup (`NewsletterWorker.astro`), shown on both the Alps and Rhine-Ruhr meetup pages:

1. **Wording** — the intro is split into two sentences:
   > Register to our Engineering Kiosk {region} newsletter (in English). Receive updates about upcoming meetups.

   The `{meetupDisplayName}` prop means this covers both Alps and Rhine-Ruhr from a single edit.

2. **New checkbox** — a preselected, `disabled` "Get notified about upcoming events" checkbox is added between the email input and the existing optional "general Engineering Kiosk newsletter (German)" opt-in.

## Why

The original single run-on sentence buried the value proposition. Splitting it reads more clearly.

The submission script already always subscribes the user to the primary meetup newsletter regardless of any checkbox. The new checkbox makes that explicit in the UI — it is informational only and changes no submission behaviour.

## Notes

- Only `src/components/meetup/NewsletterWorker.astro` changed; the legacy `Newsletter.astro` is unused by both pages and untouched.
- No JS changes: the new checkbox is not referenced by `initNewsletterWorkerForm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)