### PR TITLE
Activate registration form for Rhine-Ruhr meetup

### DIFF
--- a/src/pages/meetup/rhine-ruhr/index.astro
+++ b/src/pages/meetup/rhine-ruhr/index.astro
@@ -22,7 +22,7 @@ const sliderImages = Object.entries(imageModules).map(([path, module]) => ({
 	heroTitle="Engineering Kiosk Rhine-Ruhr Meetup Germany"
 	heroDescription="Join us at Engineering Kiosk Rhine-Ruhr, a dynamic tech meetup happening in the heart of the Rhine-Ruhr region, in Germany! This event brings together tech enthusiasts, engineers, and professionals from various fields to explore the intersection of engineering culture, open source, people and technology."
 	sliderImages={sliderImages}
-	showRegistrationForm={false}
+	showRegistrationForm={true}
 	showGeneralLanguageNote={false}
 	showNewsletterForm={true}
 	newsletterConfig={{ source: NEWSLETTER_SOURCES.MEETUP, locale: NEWSLETTER_LOCALES.EN, primaryNewsletter: NEWSLETTER_LISTS.MEETUP_RHINE_RUHR }}


### PR DESCRIPTION
Flip `showRegistrationForm` to `true` on the Rhine-Ruhr meetup index page so the RSVP section renders on `/meetup/rhine-ruhr/`, matching the Alps page.

## What changes

One line in `src/pages/meetup/rhine-ruhr/index.astro`:

```diff
- showRegistrationForm={false}
+ showRegistrationForm={true}
```

`MeetupPageLayout.astro` already contains the full registration `<section>` and the form gating logic (`showRegistrationForm` + `registrationClosed`). The form is region-agnostic — it derives the `meetup` slug from `collectionName` and reads `eventId` from the next meetup's frontmatter.

## Why this works out of the box

The upcoming June 2026 Rhine-Ruhr meetup (`src/content/meetup-rhine-ruhr/2606-krankikom.md`) already carries `eventId: '3jmd7cuuvj8loqj7vdpboatbpp'`, so the form has everything it needs the moment the flag flips.

Verified locally — the rendered `dist/meetup/rhine-ruhr/index.html` now POSTs to `https://rsvp.engineeringkiosk.dev/register` with `eventId=3jmd7cuuvj8loqj7vdpboatbpp` and `meetup=rhine-ruhr`.

## Intentionally NOT changed

`showGeneralLanguageNote` stays `false`. Unlike Alps (English-only), Rhine-Ruhr meetups are mixed German/English — e.g. `2602-check24.md` had one EN talk and one DE talk. Adding "All talks and the meetup are in English." would be wrong.

## ⚠️ Before merging

The RSVP backend at `rsvp.engineeringkiosk.dev` (separate service, not in this repo) must already:

- Recognise `meetup=rhine-ruhr` as a valid value (routing for confirmation emails, calendar, mailing list).
- Have eventId `3jmd7cuuvj8loqj7vdpboatbpp` registered for the 2026-06-10 Krankikom event.
- Send confirmation emails / ICS files with correct Rhine-Ruhr branding and venue.

If any of these isn't ready, hold this PR — otherwise users get broken-looking confirmations.

## Validation

- `make build` — ✓ clean (477 pages built)
- `make test-javascript` — ✓ 86/86 pass
- Manually inspected the rendered HTML: form action, hidden `eventId`, hidden `meetup` slug all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)