### PR TITLE
Let each meetup region override the talk-start offset

### DIFF
--- a/src/components/meetup/MeetupPageLayout.astro
+++ b/src/components/meetup/MeetupPageLayout.astro
@@ -34,6 +34,7 @@ export interface Props {
 	showNewsletterForm?: boolean;
 	newsletterConfig: { source: string; locale?: string; primaryNewsletter: string; secondaryNewsletter?: string };
 	regionDescription: string;
+	talkStartOffset?: string;
 }
 
 const {
@@ -56,6 +57,7 @@ const {
 	showNewsletterForm = false,
 	newsletterConfig,
 	regionDescription,
+	talkStartOffset = '~30min',
 } = Astro.props;
 
 const meetupSlug = collectionName.replace('meetup-', '');
@@ -66,7 +68,7 @@ const nextMeetup = getNextMeetup(bufferDays);
 const hasPastMeetups = getPastMeetups().length > 0;
 const dateString = nextMeetup ? formatDateWithoutWeekday(nextMeetup.date, 'en-US') : null;
 const timeString = nextMeetup ? formatTime(nextMeetup.date) : null;
-const dateAndTime = nextMeetup ? `${dateString} - open doors at ${timeString} (talks start ~30min later)` : null;
+const dateAndTime = nextMeetup ? `${dateString} - open doors at ${timeString} (talks start ${talkStartOffset} later)` : null;
 const registrationClosed = nextMeetup ? (nextMeetup.registrationClosed || false) : false;
 
 const description = (() => {

--- a/src/pages/meetup/rhine-ruhr/index.astro
+++ b/src/pages/meetup/rhine-ruhr/index.astro
@@ -27,6 +27,7 @@ const sliderImages = Object.entries(imageModules).map(([path, module]) => ({
 	showNewsletterForm={true}
 	newsletterConfig={{ source: NEWSLETTER_SOURCES.MEETUP, locale: NEWSLETTER_LOCALES.EN, primaryNewsletter: NEWSLETTER_LISTS.MEETUP_RHINE_RUHR }}
 	regionDescription="tech people in the Rhine-Ruhr region"
+	talkStartOffset="~1h"
 	teamBadge="The local team of Rhine-Ruhr"
 	teamTitle="Team Engineering Kiosk Rhine-Ruhr"
 	teamDescription="The organizers of Engineering Kiosk Rhine-Ruhr."


### PR DESCRIPTION
## Why

`MeetupPageLayout.astro` hard-coded `talks start ~30min later` into the date-and-time line shown above the registration form. That value is accurate for the Alps meetup, but at the Rhine-Ruhr meetup the gap between doors opening and the first talk is roughly an hour, so the line was misleading there.

## What changed

- `src/components/meetup/MeetupPageLayout.astro` — added an optional `talkStartOffset` prop with a default of `'~30min'` and threaded it into the date-and-time template literal. The Alps page does not pass the prop, so its rendered copy is byte-for-byte unchanged.
- `src/pages/meetup/rhine-ruhr/index.astro` — passes `talkStartOffset="~1h"`.

2 files changed, +4 / −1.

## Rendered output (verified against `dist/`)

- `/meetup/alps/` → `… open doors at HH:MM (talks start ~30min later)` ✓
- `/meetup/rhine-ruhr/` → `… open doors at HH:MM (talks start ~1h later)` ✓

## Validation

- `make build` → ✓ 477 pages built in 5.73s
- `make test-javascript` → ✓ 86/86
- No `website-admin/` files touched; Go commands not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)