### PR TITLE
Only render meetup registration when an eventId is set

### DIFF
--- a/src/components/meetup/MeetupPageLayout.astro
+++ b/src/components/meetup/MeetupPageLayout.astro
@@ -70,6 +70,10 @@ const dateString = nextMeetup ? formatDateWithoutWeekday(nextMeetup.date, 'en-US
 const timeString = nextMeetup ? formatTime(nextMeetup.date) : null;
 const dateAndTime = nextMeetup ? `${dateString} - open doors at ${timeString} (talks start ${talkStartOffset} later)` : null;
 const registrationClosed = nextMeetup ? (nextMeetup.registrationClosed || false) : false;
+const hasEventId = !!nextMeetup?.eventId;
+// Meetup is announced and not closed, but the RSVP eventId is not yet wired up.
+// Used to suppress the registration CTA + form until an eventId is set.
+const registrationOpening = !!nextMeetup && !registrationClosed && !hasEventId;
 
 const description = (() => {
 	if (!nextMeetup) {
@@ -175,7 +179,21 @@ const headTitle = (() => {
 												</>
 											);
 										}
-										if (!registrationClosed) {
+										if (registrationOpening) {
+											return(
+												<a
+													class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 font-medium text-center text-coolGray-500 outline-none placeholder-coolGray-500 border border-coolGray-200  rounded-md shadow-sm disabled"
+													data-scroll-to="a[name=register]"
+													href="#register"
+												>
+													Registration opens soon
+												</a>
+												<p class="mt-12 mb-2 md:mb-8 text-lg text-coolGray-500 font-medium">
+													<a class="text-yellow-500" data-scroll-to="a[name=newsletter]" href="#newsletter">
+														<span class="underline">Subscribe</span> and get an email when registration opens.
+													</a>
+												</p>)
+											} else if (!registrationClosed) {
 											return(
 												<a
 													class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 text-yellow-50 font-medium text-center bg-yellow-500 hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-500 focus:ring-opacity-50 border border-yellow-500 rounded-md shadow-sm"
@@ -230,7 +248,22 @@ const headTitle = (() => {
 				if (!nextMeetup) {
 					return null;
 				}
-				if (showRegistrationForm && !registrationClosed) {
+				if (showRegistrationForm && registrationOpening) {
+					return(
+						<section class="py-4 md:py-24 bg-white" style="background-image: url('/images/elements/pattern-white.svg'); background-position: center;">
+							<div class="container px-4 mx-auto w-full md:w-1/2">
+								<div class="mb-16 text-center">
+									<a name="register"></a>
+									<h3 class="mb-4 text-3xl md:text-5xl leading-tight text-coolGray-900 font-bold tracking-tight">Registration opens soon</h3>
+									<div class="leading-relaxed text-lg md:text-xl text-coolGray-500 font-medium">
+										Registration for the meetup on {dateString} is not yet open.<br />
+										Subscribe to the newsletter below to get notified as soon as it opens.
+									</div>
+								</div>
+							</div>
+						</section>
+					)
+				} else if (showRegistrationForm && !registrationClosed) {
 					return(
 					<section class="py-4 md:py-24 bg-white" style="background-image: url('/images/elements/pattern-white.svg'); background-position: center;">
 						<div class="container px-4 mx-auto w-full md:w-1/2">


### PR DESCRIPTION
## What

Gate the meetup registration UI on `nextMeetup.eventId` being set, in addition to the existing `registrationClosed` check.

- **Hero CTA:** When a meetup is announced but `eventId` is not yet set, the yellow *"Register for next meetup"* button is replaced with a disabled *"Registration opens soon"* button plus a newsletter-subscribe hint.
- **Registration section:** The full `<form>` (with its hidden `eventId` input) is replaced by a *"Registration opens soon"* panel pointing visitors to the newsletter.
- Closed-registration, no-upcoming-meetup, and `showRegistrationForm=false` branches are unchanged.

## Why

The registration `<form>` posts to `https://rsvp.engineeringkiosk.dev/register` with a hidden `eventId` input:

```astro
<input type="hidden" name="eventId" value={nextMeetup.eventId} />
```

When a meetup is added to the repo before its meetup.com event is created, `eventId` is missing from the frontmatter. The form then submits an empty `eventId` to the RSVP backend, which cannot resolve it. This is a recurring state — several upcoming meetups in `src/content/meetup-*/` lack `eventId` until registration is wired up.

This change suppresses the CTA + form in that state and tells visitors registration is coming, while still showing the rest of the meetup info (talks, location, date).

## Scope

Single file: `src/components/meetup/MeetupPageLayout.astro`.

- Adds two derived flags (`hasEventId`, `registrationOpening`) next to the existing `registrationClosed` line.
- Adds a `registrationOpening` branch to the hero-button IIFE.
- Adds a `showRegistrationForm && registrationOpening` branch to the registration-section IIFE.

**No schema change** — `eventId` and `registrationClosed` stay optional in `src/content.config.ts`.
**No changes to `MeetupStatsLayout.astro`** — its `eventId` usage is already null-safe.

## Verification

- `make build` — 477 pages built, complete.
- `make test-javascript` — 86/86 tests pass.
- Manual check: comment out `eventId` on an upcoming meetup → hero shows "Registration opens soon" button; registration section shows the placeholder panel; restore `eventId` → yellow "Register" CTA + working form return; set `registrationClosed: true` → existing closed-registration UI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)