### PR TITLE
Fix promote social image: city, logo, URL, background + per-meetup override

### DIFF
--- a/docs/meetup-promote-background-image.md
+++ b/docs/meetup-promote-background-image.md
@@ -1,0 +1,82 @@
+# Meetup promote page: background image
+
+This document explains how to change the background image of the social-share / promote page that lives at `/meetup/<region>/promote/` (e.g. [engineeringkiosk.dev/meetup/rhine-ruhr/promote/](https://engineeringkiosk.dev/meetup/rhine-ruhr/promote/)).
+
+The same asset is also used as the page's Open Graph preview (`<meta property="og:image">`), i.e. what social platforms render when the page URL is shared.
+
+## How the image is rendered
+
+The promote page paints a 700×700 px canvas with the image as a CSS background and the next-meetup details (date, city, host, talks) overlaid on top.
+
+CSS used:
+
+```css
+background-size: cover;
+background-position: center;
+background-repeat: no-repeat;
+```
+
+- Square assets fill the canvas with no cropping.
+- Off-aspect assets (e.g. 16:9) are scaled to cover the square and **center-cropped** on the long sides.
+
+## Recommended dimensions
+
+| Use         | Width × Height | Aspect | Notes                                                                                |
+| ----------- | -------------- | ------ | ------------------------------------------------------------------------------------ |
+| Recommended | 1200×1200      | 1:1    | Crisp on retina, square OG preview accepted by Facebook, X/Twitter and LinkedIn      |
+| Minimum     | 700×700        | 1:1    | Exact canvas size — may look soft on retina displays                                 |
+| Avoid       | non-square     | ≠ 1:1  | Will be center-cropped by `background-size: cover` (top/bottom or sides get clipped) |
+
+Format: JPG or PNG. Keep file size reasonable (< 500 kB) — the asset is loaded both for the visible page and for social preview crawlers.
+
+## Where to put the file
+
+Drop the image into the region's public images folder:
+
+```
+public/meetup/<region>/images/<your-file>.jpg
+```
+
+Existing examples:
+
+- `public/meetup/rhine-ruhr/images/rr.jpg` — Rhine-Ruhr default
+- `public/meetup/alps/images/ibk.jpg` — Alps default
+
+A naming convention like `<event-id>-<short-slug>.jpg` (e.g. `2606-duisburg.jpg`) keeps per-event assets easy to find.
+
+## Setting it per meetup (recommended)
+
+Add the optional `promoteBackgroundImage` field to the meetup's frontmatter, referencing the asset by its absolute public path:
+
+```yaml
+---
+date: 2026-06-10T18:00:00+02:00
+promoteBackgroundImage: '/meetup/rhine-ruhr/images/2606-duisburg.jpg'
+location:
+  name: 'Krankikom GmbH'
+  address: 'Calaisplatz 5, 47051 Duisburg'
+  # ...
+talks:
+  # ...
+---
+```
+
+The schema field is defined on `meetupSchema` in [`src/content.config.ts`](../src/content.config.ts) and shared by both `meetup-alps` and `meetup-rhine-ruhr` collections.
+
+## Changing the region-wide default
+
+If you want to swap the default that's used **when no per-meetup override is set**, replace the file the page currently points to. The default path is wired in the region's promote page:
+
+- Rhine-Ruhr: [`src/pages/meetup/rhine-ruhr/promote/index.astro`](../src/pages/meetup/rhine-ruhr/promote/index.astro) → `ogImage="/meetup/rhine-ruhr/images/rr.jpg"`
+- Alps: [`src/pages/meetup/alps/promote/index.astro`](../src/pages/meetup/alps/promote/index.astro) → `ogImage="/meetup/alps/images/ibk.jpg"`
+
+Either overwrite the file at that path with a new square asset, or change the path in the `.astro` file to point at a new asset.
+
+## Fallback behavior
+
+The component (`src/components/meetup/PromoteSocialImage.astro`) picks the effective image like this:
+
+1. If there is an upcoming meetup **and** it has `promoteBackgroundImage` set → that wins.
+2. Otherwise → the region's default `ogImage` prop.
+
+The chosen image drives both the visible background **and** the `og:image` meta tag, so social previews stay in sync with what visitors see on the page.

--- a/src/components/meetup/PromoteSocialImage.astro
+++ b/src/components/meetup/PromoteSocialImage.astro
@@ -34,17 +34,22 @@ const addressCity = nextMeetup?.location.address
 	?.trim();
 const displayCity = addressCity ?? meetupCity;
 
+// Per-meetup override (frontmatter field `promoteBackgroundImage`)
+// falls back to the page-level default prop when not set on the
+// upcoming meetup or when there is no upcoming meetup.
+const effectiveOgImage = nextMeetup?.promoteBackgroundImage ?? ogImage;
+
 const defaultAvatarPath = `/meetup/${meetupUrl}/images/speaker/avatar.png`;
 
 ---
 
 <html lang="de">
 	<head>
-		<MainHead title={title} description={description} image={ogImage} {canonicalURL} noindex />
+		<MainHead title={title} description={description} image={effectiveOgImage} {canonicalURL} noindex />
 	</head>
 
 	<body class="antialiased bg-body text-body font-body">
-		<section style={`background-image: url('${ogImage}'); width: 700px; height: 700px;`} class="block text-center flex flex-col font-medium">
+		<section style={`background-image: url('${effectiveOgImage}'); background-size: cover; background-position: center; background-repeat: no-repeat; width: 700px; height: 700px;`} class="block text-center flex flex-col font-medium">
 			<h1 class="text-white text-5xl font-semibold p-3">Engineering Kiosk {meetupName}</h1>
 			{nextMeetup ? (
 				<>

--- a/src/components/meetup/PromoteSocialImage.astro
+++ b/src/components/meetup/PromoteSocialImage.astro
@@ -25,6 +25,15 @@ const bufferDays = 1;
 const nextMeetup = getNextMeetup(bufferDays);
 const dateString = nextMeetup ? formatDate(nextMeetup.date, 'en-US') : null;
 
+// Derive the city of the upcoming meetup from its address (e.g.
+// "Calaisplatz 5, 47051 Duisburg" → "Duisburg"). This auto-tracks
+// multi-city regions; falls back to the static `meetupCity` prop if
+// no postal-code pattern is found or there is no upcoming meetup.
+const addressCity = nextMeetup?.location.address
+	?.match(/\d{4,5}\s+([^,]+)/)?.[1]
+	?.trim();
+const displayCity = addressCity ?? meetupCity;
+
 const defaultAvatarPath = `/meetup/${meetupUrl}/images/speaker/avatar.png`;
 
 ---
@@ -40,11 +49,11 @@ const defaultAvatarPath = `/meetup/${meetupUrl}/images/speaker/avatar.png`;
 			{nextMeetup ? (
 				<>
 					<h2 class="text-white text-4xl">{dateString}</h2>
-					<h2 class="text-white text-4xl">Meetup in {meetupCity}</h2>
-					<div class="text-2xl p-4">engineeringkiosk.dev/{meetupUrl}</div>
+					<h2 class="text-white text-4xl">Meetup in {displayCity}</h2>
+					<div class="text-2xl p-4">https://engineeringkiosk.dev/{meetupUrl}</div>
 					<div class="bg-white bg-opacity-90 mt-auto p-4 relative">
 						<div class="text-2xl">
-							hosted by {nextMeetup.location.logo ? <Image class="h-12 inline" src={nextMeetup.location.logo} alt={nextMeetup.location.name} /> : nextMeetup.location.name}
+							hosted by {nextMeetup.location.logo ? <Image class="h-12 w-auto inline" src={nextMeetup.location.logo} alt={nextMeetup.location.name} /> : nextMeetup.location.name}
 						</div>
 					{nextMeetup.talks.map((talk) => (
 						<div class="flex flex-row my-2 mx-4">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -58,6 +58,11 @@ const meetupSchema = ({ image }) =>
 		date: z.date(),
 		eventId: z.string().optional(),
 		registrationClosed: z.boolean().optional(),
+		// Per-event override for the promote-page background image (also
+		// used as the page's Open Graph preview). Absolute /public/ path,
+		// e.g. "/meetup/rhine-ruhr/images/2606-duisburg.jpg". Square 1200×1200
+		// is the recommended target. Omit to fall back to the region default.
+		promoteBackgroundImage: z.string().optional(),
 		location: z.object({
 			name: z.string(),
 			address: z.string(),


### PR DESCRIPTION
Fixes four visible issues on `/meetup/<region>/promote/` (the social-share / Open Graph page) and adds a per-meetup override for the background image. Found while preparing promotion for the 10 Jun 2026 Rhine-Ruhr meetup at Krankikom in Duisburg.

## Commit 1 — Three defects in the rendered social image

1. **Hardcoded city.** The image said *"Meetup in Düsseldorf"* even though the next event is in Duisburg. The `meetupCity` prop was static at page level, so it can no longer represent "the next meetup's city" now that Rhine-Ruhr spans multiple cities. Derived the displayed city from `nextMeetup.location.address` via a postal-code regex (`/\d{4,5}\s+([^,]+)/`); falls back to the prop when no upcoming meetup exists or no postal code is found. Verified against every existing meetup address.
2. **Stretched host logo.** Astro's `<Image>` stamps `width`/`height` HTML attributes from the source; `class="h-12 inline"` overrode CSS height but left the HTML width attribute dictating the rendered width — so the logo stretched across the full footer band. Added `w-auto` to let the browser preserve the natural aspect ratio against the 48 px height.
3. **URL missing scheme.** Rendered as `engineeringkiosk.dev/<region>`. Prefixed with `https://` to match the sibling `PromoteNewsletter` / `PromoteAnnounceNewsletter` components and to be directly copy-pasteable.

Single file touched: `src/components/meetup/PromoteSocialImage.astro` (+12 / −3). Both Rhine-Ruhr and Alps benefit because they share the component.

## Commit 2 — Background image: fix zoom + make it per-meetup configurable

The background looked "zoomed in" because the inline style set `background-image` but omitted `background-size`. The Rhine-Ruhr default `rr.jpg` is 1280×720 — wider than the 700×700 canvas — so only the top-left ~700×700 chunk was visible. Alps (`ibk.jpg`, 700×700) wasn't affected.

- **CSS fix** — added `background-size: cover; background-position: center; background-repeat: no-repeat;` on the `<section>`. Square assets fill the canvas without cropping; off-aspect assets are center-cropped (already a major improvement over the broken top-left clip).
- **Per-meetup override** — new optional `promoteBackgroundImage: z.string().optional()` field on the shared `meetupSchema`. Each meetup `.md` can set its own asset; absent → falls back to the region-level default. The chosen image drives **both** the visible background and `<meta property="og:image">` so social previews stay in sync.
- **Docs** — new `docs/` folder (first file in it): `docs/meetup-promote-background-image.md` covers rendering behavior, recommended dimensions (1200×1200 square), where to drop assets, the frontmatter override field, and the fallback chain. Style mirrors README's "Blog posts: Image sizes" section.

Files touched: `src/content.config.ts`, `src/components/meetup/PromoteSocialImage.astro`, `docs/meetup-promote-background-image.md`.

## Recommended asset for new backgrounds

| Use         | Width × Height | Aspect | Notes                                                                                |
| ----------- | -------------- | ------ | ------------------------------------------------------------------------------------ |
| Recommended | 1200×1200      | 1:1    | Crisp on retina, square OG accepted by Facebook, X/Twitter, LinkedIn                 |
| Minimum     | 700×700        | 1:1    | Exact canvas match — may look soft on retina                                         |
| Avoid       | non-square     | ≠ 1:1  | Center-cropped by `background-size: cover`                                           |

The existing `rr.jpg` (1280×720) is left in place; it now renders centered with mild side-cropping. A 1200×1200 redesign can land later as a content change.

## Validation

- `npx vitest run` → 86/86 passing
- `npx astro build` → 477 pages built, schema change accepted by all existing meetup `.md`
- Smoke-tested the override path by temporarily setting `promoteBackgroundImage` on the Krankikom entry and confirming the page picks it up (reverted before commit)

## Out of scope (intentionally)

- Replacing the default `rr.jpg` with a fresh 1200×1200 design — content task, not blocking.
- Updating `meetupCity="Düsseldorf"` in the three rhine-ruhr promote-page props — it only affects the page `<title>` / meta description, not the visible OG image; can be revisited if you want region-named meta.
- Newsletter / announce-newsletter components — their `ogImage` is meta-only, no visible background, so the override pathway wasn't added there. Easy follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)