### PR TITLE
Make meetup in-page anchor links update the URL hash

### DIFF
--- a/src/components/meetup/MeetupPageLayout.astro
+++ b/src/components/meetup/MeetupPageLayout.astro
@@ -166,13 +166,12 @@ const headTitle = (() => {
 												<>
 													<a
 														class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 text-yellow-50 font-medium text-center bg-yellow-500 hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-500 focus:ring-opacity-50 border border-yellow-500 rounded-md shadow-sm"
-														data-scroll-to="a[name=newsletter]"
 														href="#newsletter"
 													>
 														Subscribe to Newsletter
 													</a>
 													<p class="mt-12 mb-2 md:mb-8 text-lg text-coolGray-500 font-medium">
-														<a class="text-yellow-500" data-scroll-to="a[name=newsletter]" href="#newsletter">
+														<a class="text-yellow-500" href="#newsletter">
 															<span class="underline">Subscribe</span> and get an email when the next meetup is announced.
 														</a>
 													</p>
@@ -183,13 +182,12 @@ const headTitle = (() => {
 											return(
 												<a
 													class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 font-medium text-center text-coolGray-500 outline-none placeholder-coolGray-500 border border-coolGray-200  rounded-md shadow-sm disabled"
-													data-scroll-to="a[name=register]"
 													href="#register"
 												>
 													Registration opens soon
 												</a>
 												<p class="mt-12 mb-2 md:mb-8 text-lg text-coolGray-500 font-medium">
-													<a class="text-yellow-500" data-scroll-to="a[name=newsletter]" href="#newsletter">
+													<a class="text-yellow-500" href="#newsletter">
 														<span class="underline">Subscribe</span> and get an email when registration opens.
 													</a>
 												</p>)
@@ -197,13 +195,12 @@ const headTitle = (() => {
 											return(
 												<a
 													class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 text-yellow-50 font-medium text-center bg-yellow-500 hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-500 focus:ring-opacity-50 border border-yellow-500 rounded-md shadow-sm"
-													data-scroll-to="a[name=register]"
 													href="#register"
 												>
 													Register for next meetup
 												</a>
 												 <p class="mt-12 mb-2 md:mb-8 text-lg text-coolGray-500 font-medium">
-													<a class="text-yellow-500" data-scroll-to="a[name=newsletter]" href="#newsletter">
+													<a class="text-yellow-500" href="#newsletter">
 														<span class="underline">Subscribe</span> and get an email when the next meetup is announced.
 													</a>
 												</p>)
@@ -211,13 +208,12 @@ const headTitle = (() => {
 											return(
 												<a
 													class="inline-block py-5 px-7 w-full text-base md:text-lg leading-4 font-medium text-center text-coolGray-500 outline-none placeholder-coolGray-500 border border-coolGray-200  rounded-md shadow-sm disabled"
-													data-scroll-to="a[name=register]"
 													href="#register"
 												>
 													Registration is closed (Max. Capacity Reached)
 												</a>
 												<p class="mt-12 mb-2 md:mb-8 text-lg text-coolGray-500 font-medium">
-													<a class="text-yellow-500" data-scroll-to="a[name=newsletter]" href="#newsletter">
+													<a class="text-yellow-500" href="#newsletter">
 														We have reached the maximum number of registrations for this event. <span class="underline">Please do not show up if you have not registered beforehand</span> as the venue has limited capacity due to safety regulations. You can subscribe to our newsletter and get an email when the next meetup is announced. Hope to see you there!
 													</a>
 												</p>)
@@ -425,17 +421,5 @@ const headTitle = (() => {
 
 			<Footer />
 		</div>
-
-		<script>
-			document.querySelectorAll('[data-scroll-to]').forEach((el) => {
-				el.addEventListener('click', (e) => {
-					e.preventDefault();
-					const target = document.querySelector(el.getAttribute('data-scroll-to'));
-					if (target) {
-						window.scrollTo({ top: target.offsetTop, behavior: 'smooth' });
-					}
-				});
-			});
-		</script>
 	</body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,10 @@
 @plugin '@tailwindcss/typography';
 
 @layer base {
+	html {
+		scroll-behavior: smooth;
+	}
+
 	body {
 		@apply text-gray-700;
 	}


### PR DESCRIPTION
On `/meetup/alps/` and `/meetup/rhine-ruhr/`, the **Subscribe to Newsletter** and **Register for next meetup** buttons (plus their inline-text counterparts further down the page) smoothly scrolled to the relevant in-page section but never updated the URL bar with `#newsletter` / `#register`. That made the result un-shareable: visitors couldn't copy the URL after clicking to send a deep link.

## Cause

A click handler in `MeetupPageLayout.astro` called `e.preventDefault()` and performed a manual `window.scrollTo(...)`, bypassing the browser's native anchor navigation that would have updated `location.hash` and pushed a history entry for free. The handler did nothing else — no focus management, no analytics, no sticky-header offset, no `prefers-reduced-motion` handling — so dropping it only forfeited the smooth scroll, which CSS `scroll-behavior: smooth` replaces.

## Changes

- **`src/components/meetup/MeetupPageLayout.astro`** — Remove the `data-scroll-to` click handler and the eight `data-scroll-to` attribute uses on the affected anchors. Keep each anchor's `href="#newsletter"` / `href="#register"` so the browser resolves them natively to the existing `<a name="…">` targets (legacy named-anchor lookup, still supported by all modern browsers).
- **`src/styles/global.css`** — Add `html { scroll-behavior: smooth; }` inside the existing `@layer base { … }` block so anchor jumps stay animated site-wide.

## Verification

- `make build` → 477 pages built, no errors.
- `make test-javascript` → 86 / 86 tests pass.
- Manual on `/meetup/alps/` and `/meetup/rhine-ruhr/`:
  - Clicking each top button → smooth scroll **and** the URL bar updates with `#newsletter` / `#register`.
  - Inline-text duplicates of those links behave the same.
  - Back / Forward navigates between scroll positions as expected.
  - Opening `…/meetup/alps/#newsletter` directly in a new tab still jumps to the newsletter section on load.

## Out of scope (intentionally)

- `@media (prefers-reduced-motion: reduce)` override — the previous JS didn't honor it either, so not a regression; happy to add as a one-line follow-up if desired.
- Migrating `<a name="…">` targets to `id="…"` — out of scope; the legacy form is still universally supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)