### PR TITLE
Configure git identity before rebase in auto-commit workflows

### DIFF
--- a/.github/workflows/check-tags-without-descriptions.yml
+++ b/.github/workflows/check-tags-without-descriptions.yml
@@ -51,6 +51,13 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -39,6 +39,12 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         run: |

--- a/.github/workflows/sync-awesome-software-engineering-games.yml
+++ b/.github/workflows/sync-awesome-software-engineering-games.yml
@@ -42,6 +42,13 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/sync-awesome-software-engineering-movies.yml
+++ b/.github/workflows/sync-awesome-software-engineering-movies.yml
@@ -42,6 +42,13 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/sync-german-tech-podcasts.yml
+++ b/.github/workflows/sync-german-tech-podcasts.yml
@@ -42,6 +42,13 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/update-podcast-episodes-from-rss.yml
+++ b/.github/workflows/update-podcast-episodes-from-rss.yml
@@ -54,6 +54,13 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Problem

The auto-commit workflows failed with `fatal: empty ident name ... not allowed` (exit 128) — see [run 26842996203](https://github.com/EngineeringKiosk/webpage/actions/runs/26842996203):

```
Push failed, pulling with rebase and retrying...
Rebasing (1/1)
Committer identity unknown
*** Please tell me who you are.
fatal: empty ident name (...) not allowed
Error: Process completed with exit code 128.
```

## Root cause

These workflows use `stefanzweifel/git-auto-commit-action` with `skip_push: true`, then push via a custom **"Push changes with retry"** step that runs `git pull --rebase origin main` when the first push is rejected as non-fast-forward.

The action's `commit_user_name` / `commit_user_email` inputs apply **only to the commit the action creates** — they are **not** persisted to the repository's `git config`. When the retry step rebases, git replays the local commit and needs a committer identity from `git config`, which was never set → `empty ident name`.

## Fix

Add a `Configure git identity for rebase` step that runs `git config` before the retry push, gated by the same `changes_detected` condition. This mirrors the working pattern already used in the data-generation repos (and `podcast-metadata`'s `state-manager.yml`).

Applied to all 6 auto-commit workflows in this repo:
- `prettier.yml`
- `check-tags-without-descriptions.yml`
- `update-podcast-episodes-from-rss.yml`
- `sync-german-tech-podcasts.yml`
- `sync-awesome-software-engineering-movies.yml`
- `sync-awesome-software-engineering-games.yml`

## Verification

- Diff is additions only (one step per file).
- Each step sits between the `id: auto-commit` step and `Push changes with retry`, matching each file's existing `working-directory` style.
- End-to-end proof: the next run that hits a concurrent-push rebase completes without the `empty ident name` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)