### PR TITLE
Reorder footer social media links and add Threads

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,7 +74,7 @@ const year = new Date().getFullYear();
 				<h3 class="mb-5 text-lg font-bold text-coolGray-900">Social Media</h3>
 				<ul>
 					{
-						['x', 'mastodon', 'instagram', 'youTube', 'linkedin', 'tiktok', 'github', 'bluesky'].map((social) => (
+						['linkedin', 'mastodon', 'bluesky', 'threads', 'x', 'instagram', 'youTube', 'github', 'tiktok'].map((social) => (
 							<li class="mb-4">
 								<a class="inline-block text-coolGray-500 hover:text-coolGray-600 font-medium" href={podcastInfo.socials[social].link} title={podcastInfo.socials[social].linkTitle}>
 									<img src={podcastInfo.socials[social].icon} class="inline w-6 mr-2" alt={podcastInfo.socials[social].iconAlt} title={podcastInfo.socials[social].iconTitle} /> {podcastInfo.socials[social].name}

--- a/src/data/podcast-info.json
+++ b/src/data/podcast-info.json
@@ -17,23 +17,14 @@
     "antennaPod": "https://antennapod.org/de/deeplink/subscribe?url=https://engineeringkiosk.dev/podcast/rss"
   },
   "socials": {
-    "youTube": {
-      "name": "YouTube",
-      "handle": "@engineeringkiosk",
-      "link": "https://www.youtube.com/@engineeringkiosk",
-      "linkTitle": "Engineering Kiosk auf YouTube (@engineeringkiosk)",
-      "icon": "/images/brands/youtube.svg",
-      "iconAlt": "YouTube logo",
-      "iconTitle": "YouTube logo"
-    },
-    "x": {
-      "name": "X",
-      "handle": "@EngKiosk",
-      "link": "https://x.com/engkiosk/",
-      "linkTitle": "Engineering Kiosk auf X (@EngKiosk)",
-      "icon": "/images/brands/x_black.svg",
-      "iconAlt": "X logo",
-      "iconTitle": "X logo"
+    "linkedin": {
+      "name": "LinkedIn",
+      "handle": "@engineering-kiosk",
+      "link": "https://www.linkedin.com/company/engineering-kiosk/",
+      "linkTitle": "Engineering Kiosk auf LinkedIn (@engineering-kiosk)",
+      "icon": "/images/brands/linkedin_blue.svg",
+      "iconAlt": "LinkedIn logo",
+      "iconTitle": "LinkedIn logo"
     },
     "mastodon": {
       "name": "Mastodon",
@@ -44,6 +35,33 @@
       "iconAlt": "Mastodon logo",
       "iconTitle": "Mastodon logo"
     },
+    "bluesky": {
+      "name": "Bluesky",
+      "handle": "@engineeringkiosk.dev",
+      "link": "https://bsky.app/profile/engineeringkiosk.dev",
+      "linkTitle": "Engineering Kiosk auf Bluesky (@engineeringkiosk.dev)",
+      "icon": "/images/brands/bluesky.svg",
+      "iconAlt": "Bluesky logo",
+      "iconTitle": "Bluesky logo"
+    },
+    "threads": {
+      "name": "Threads",
+      "handle": "@engineeringkiosk",
+      "link": "https://www.threads.com/@engineeringkiosk",
+      "linkTitle": "Engineering Kiosk auf Threads (@engineeringkiosk)",
+      "icon": "/images/brands/threads.svg",
+      "iconAlt": "Threads logo",
+      "iconTitle": "Threads logo"
+    },
+    "x": {
+      "name": "X",
+      "handle": "@EngKiosk",
+      "link": "https://x.com/engkiosk/",
+      "linkTitle": "Engineering Kiosk auf X (@EngKiosk)",
+      "icon": "/images/brands/x_black.svg",
+      "iconAlt": "X logo",
+      "iconTitle": "X logo"
+    },
     "instagram": {
       "name": "Instagram",
       "handle": "@engineeringkiosk",
@@ -53,23 +71,14 @@
       "iconAlt": "Instagram logo",
       "iconTitle": "Instagram logo"
     },
-    "linkedin": {
-      "name": "LinkedIn",
-      "handle": "@engineering-kiosk",
-      "link": "https://www.linkedin.com/company/engineering-kiosk/",
-      "linkTitle": "Engineering Kiosk auf LinkedIn (@engineering-kiosk)",
-      "icon": "/images/brands/linkedin_blue.svg",
-      "iconAlt": "LinkedIn logo",
-      "iconTitle": "LinkedIn logo"
-    },
-    "tiktok": {
-      "name": "TikTok",
+    "youTube": {
+      "name": "YouTube",
       "handle": "@engineeringkiosk",
-      "link": "https://www.tiktok.com/@engineeringkiosk",
-      "linkTitle": "Engineering Kiosk auf TikTok (@engineeringkiosk)",
-      "icon": "/images/brands/tiktok.svg",
-      "iconAlt": "TikTok logo",
-      "iconTitle": "TikTok logo"
+      "link": "https://www.youtube.com/@engineeringkiosk",
+      "linkTitle": "Engineering Kiosk auf YouTube (@engineeringkiosk)",
+      "icon": "/images/brands/youtube.svg",
+      "iconAlt": "YouTube logo",
+      "iconTitle": "YouTube logo"
     },
     "github": {
       "name": "GitHub",
@@ -80,14 +89,14 @@
       "iconAlt": "GitHub logo",
       "iconTitle": "GitHub logo"
     },
-    "bluesky": {
-      "name": "Bluesky",
-      "handle": "@engineeringkiosk.dev",
-      "link": "https://bsky.app/profile/engineeringkiosk.dev",
-      "linkTitle": "Engineering Kiosk auf Bluesky (@engineeringkiosk.dev)",
-      "icon": "/images/brands/bluesky.svg",
-      "iconAlt": "Bluesky logo",
-      "iconTitle": "Bluesky logo"
+    "tiktok": {
+      "name": "TikTok",
+      "handle": "@engineeringkiosk",
+      "link": "https://www.tiktok.com/@engineeringkiosk",
+      "linkTitle": "Engineering Kiosk auf TikTok (@engineeringkiosk)",
+      "icon": "/images/brands/tiktok.svg",
+      "iconAlt": "TikTok logo",
+      "iconTitle": "TikTok logo"
     }
   }
 }


### PR DESCRIPTION
## What

Reorders the **Social Media** presence in the site footer and adds the Engineering Kiosk **Threads** account (`https://www.threads.com/@engineeringkiosk`), which previously had no entry in the org-level social data.

New order:

1. LinkedIn
2. Mastodon
3. Bluesky
4. Threads
5. X
6. Instagram
7. YouTube
8. GitHub
9. TikTok

## Changes

- `src/data/podcast-info.json` — add a `threads` entry and reorder the `socials` keys to match the new display order.
- `src/components/Footer.astro` — reorder the explicit key array that drives the footer render order.

## Icons

No new asset needed: the official Threads logo already lived at `public/images/brands/threads.svg` (black "@-ribbon" mark, also used by the per-person `SocialLinks` component). It matches the black X icon already used in the footer.

## Scope

Footer / org-level only. The per-person `SocialLinks.astro` component, `linktree.astro` (curated subset), and `kontakt.astro` (contact-context links) were intentionally left untouched.

## Verification

- `make build` → completed; built footer output matches the target order exactly.
- `make test-javascript` → 86 tests passed.
- Both edited files pass `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)